### PR TITLE
Fix review findings: is_online, release workflow, CI, code quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --locked --verbose
+
+      - name: Test
+        run: cargo test --locked --verbose

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -5,10 +5,14 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -41,152 +45,44 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.rust_target }}
 
-      - name: Install cargo binaries
-        run: |
-          cargo install cargo-bundle-licenses
-          cargo bundle-licenses --version
-
       - name: Build project
         run: |
           cargo build --release --locked --target ${{ matrix.rust_target }}
 
       - name: Package binaries
+        shell: bash
         run: |
           mkdir -p release_binaries
           cp target/${{ matrix.rust_target }}/release/asphyxia release_binaries/
           chmod +x release_binaries/asphyxia || true
           cd release_binaries
-          if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            mv asphyxia asphyxia.exe
-            zip ../asphyxia-${{ matrix.os }}-${{ matrix.arch }}.zip asphyxia.exe
-          else
-            zip ../asphyxia-${{ matrix.os }}-${{ matrix.arch }}.zip asphyxia
-          fi
+          zip ../asphyxia-${{ matrix.rust_target }}.zip asphyxia
           cd ..
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.os }}-${{ matrix.arch }}
-          path: asphyxia-${{ matrix.os }}-${{ matrix.arch }}.zip
-
-    outputs:
-      tag_name: ${{ github.ref_name }}
+          name: binaries-${{ matrix.rust_target }}
+          path: asphyxia-${{ matrix.rust_target }}.zip
 
   create-release:
     needs: build-and-release
     runs-on: ubuntu-latest
     steps:
-      - name: Get version from tag
-        id: get_version
-        run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ env.VERSION }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
-
-      # Download all artifacts
-      - name: Download Artifacts (Linux x86_64)
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-ubuntu-latest-x86_64
-          path: artifacts/linux-x86_64
-      - name: Download Artifacts (Linux arm64)
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-ubuntu-latest-arm64
-          path: artifacts/linux-arm64
-      - name: Download Artifacts (MacOS x86_64)
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-macos-latest-x86_64
-          path: artifacts/macos-x86_64
-      - name: Download Artifacts (MacOS arm64)
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-macos-latest-arm64
-          path: artifacts/macos-arm64
-      - name: Download Artifacts (Windows x86_64)
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-windows-latest-x86_64
-          path: artifacts/windows-x86_64
-      # Если нужно, раскомментируйте для Windows ARM64
-      # - name: Download Artifacts (Windows arm64)
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: binaries-windows-latest-arm64
-      #     path: artifacts/windows-arm64
-
-      # Upload all binaries to release
-      - name: Upload Linux x86_64 Binary to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/linux-x86_64/asphyxia-ubuntu-latest-x86_64.zip
-          asset_name: asphyxia-${{ env.VERSION }}-linux-x86_64.zip
-          asset_content_type: application/zip
-
-      - name: Upload Linux arm64 Binary to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/linux-arm64/asphyxia-ubuntu-latest-arm64.zip
-          asset_name: asphyxia-${{ env.VERSION }}-linux-arm64.zip
-          asset_content_type: application/zip
-
-      - name: Upload MacOS x86_64 Binary to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/macos-x86_64/asphyxia-macos-latest-x86_64.zip
-          asset_name: asphyxia-${{ env.VERSION }}-macos-x86_64.zip
-          asset_content_type: application/zip
-
-      - name: Upload MacOS arm64 Binary to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/macos-arm64/asphyxia-macos-latest-arm64.zip
-          asset_name: asphyxia-${{ env.VERSION }}-macos-arm64.zip
-          asset_content_type: application/zip
-
-      - name: Upload Windows x86_64 Binary to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/windows-x86_64/asphyxia-windows-latest-x86_64.zip
-          asset_name: asphyxia-${{ env.VERSION }}-windows-x86_64.zip
-          asset_content_type: application/zip
-
-      # Если нужно, раскомментируйте для Windows ARM64
-      # - name: Upload Windows arm64 Binary to Release
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: artifacts/windows-arm64/asphyxia-windows-latest-arm64.zip
-      #     asset_name: asphyxia-${{ env.VERSION }}-windows-arm64.zip
-      #     asset_content_type: application/zip
+          files: artifacts/asphyxia-*.zip
 
   updatehomebrew:
     needs: create-release
@@ -195,48 +91,36 @@ jobs:
       - name: Checkout brew tap repo
         uses: actions/checkout@v4
         with:
-          repository: jtprogru/homebrew-asphyxia # замени на свой
+          repository: jtprogru/homebrew-asphyxia
           ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
-      - name: Download macOS x86_64 binary
+      - name: Download macOS artifacts
         uses: actions/download-artifact@v4
         with:
-          name: binaries-macos-latest-x86_64
-          path: artifacts/macos-x86_64
-      - name: Download macOS arm64 binary
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-macos-latest-arm64
-          path: artifacts/macos-arm64
-
-      - name: Calculate SHA256 (x86_64)
-        id: sha_x86_64
-        run: |
-          SHA=$(sha256sum artifacts/macos-x86_64/asphyxia-macos-latest-x86_64.zip | awk '{print $1}')
-          echo "sha_x86_64=$SHA" >> $GITHUB_ENV
-      - name: Calculate SHA256 (arm64)
-        id: sha_arm64
-        run: |
-          SHA=$(sha256sum artifacts/macos-arm64/asphyxia-macos-latest-arm64.zip | awk '{print $1}')
-          echo "sha_arm64=$SHA" >> $GITHUB_ENV
+          path: artifacts
+          merge-multiple: true
 
       - name: Generate Formula
         run: |
-          VERSION=${{ env.VERSION }}
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          SHA_X86_64=$(sha256sum artifacts/asphyxia-x86_64-apple-darwin.zip | awk '{print $1}')
+          SHA_ARM64=$(sha256sum artifacts/asphyxia-aarch64-apple-darwin.zip | awk '{print $1}')
+          mkdir -p Formula
           cat <<EOL > Formula/asphyxia.rb
           class Asphyxia < Formula
-            desc "Short description of your tool"
+            desc "A fast and efficient network scanner written in Rust"
             homepage "https://github.com/jtprogru/asphyxia"
             version "${VERSION}"
 
             if OS.mac? && Hardware::CPU.intel?
-              url "https://github.com/jtprogru/asphyxia/releases/download/v${VERSION}/asphyxia-${VERSION}-macos-x86_64.zip"
-              sha256 "${{ env.sha_x86_64 }}"
+              url "https://github.com/jtprogru/asphyxia/releases/download/${TAG}/asphyxia-x86_64-apple-darwin.zip"
+              sha256 "${SHA_X86_64}"
             end
             if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/jtprogru/asphyxia/releases/download/v${VERSION}/asphyxia-${VERSION}-macos-arm64.zip"
-              sha256 "${{ env.sha_arm64 }}"
+              url "https://github.com/jtprogru/asphyxia/releases/download/${TAG}/asphyxia-aarch64-apple-darwin.zip"
+              sha256 "${SHA_ARM64}"
             end
 
             def install
@@ -250,5 +134,5 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add Formula/asphyxia.rb
-          git commit -m "Update asphyxia to v${{ env.VERSION }}"
+          git commit -m "Update asphyxia to ${GITHUB_REF_NAME}" || echo "No changes to commit"
           git push origin main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ edition = "2024"
 authors = [
     "Mikhail Savin <jtprogru@gmail.com>"
 ]
+description = "A fast and efficient network scanner written in Rust"
+license = "MIT"
+repository = "https://github.com/jtprogru/asphyxia"
+homepage = "https://github.com/jtprogru/asphyxia"
+readme = "README.md"
+keywords = ["network", "scanner", "port", "cli", "security"]
+categories = ["command-line-utilities", "network-programming"]
 
 [dependencies]
 clap = { version="4.5.40", features = ["derive"] }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,5 +67,5 @@ pub enum Args {
         /// Scan a range of IP addresses
         #[arg(short = 'r', long, num_args = 2, group = "scan_type")]
         range: Option<Vec<String>>,
-    }
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub mod cli;
 pub mod scanner;
 pub mod utils;
 
+pub use scanner::address::{scan_address, scan_ip_range, scan_subnet};
 /// Re-export commonly used types and functions
-pub use scanner::port::{scan_port, is_online};
-pub use scanner::address::{scan_address, scan_subnet, scan_ip_range};
-pub use utils::{parse_ports, parse_ipv4, parse_subnet};
+pub use scanner::port::{is_online, resolve_host, scan_port};
+pub use utils::{parse_ipv4, parse_ports, parse_subnet};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,29 @@
-use std::net::{Ipv4Addr};
-use std::time::Duration;
+use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
-use rayon::prelude::*;
 use owo_colors::OwoColorize;
+use rayon::prelude::*;
 
 mod cli;
 mod scanner;
 mod utils;
 
 use cli::Args;
-use scanner::{port, address};
+use scanner::{address, port};
 use utils::{parse_ipv4, parse_subnet};
 
 fn main() {
     let args = Args::parse();
 
     match args {
-        Args::PortScan { host, range, specific } => {
+        Args::PortScan {
+            host,
+            range,
+            specific,
+        } => {
             // Check if host is online
             if !port::is_online(&host) {
                 eprintln!("{}", format!("Server/Host: {} is not up!", host).red());
@@ -27,10 +31,7 @@ fn main() {
             }
 
             let ports: Vec<u16> = if let Some(range) = range {
-                if range.len() != 2 {
-                    eprintln!("{}", "Range requires two numbers".yellow());
-                    return;
-                }
+                // clap enforces exactly two values via `num_args = 2`.
                 let start = range[0];
                 let end = range[1];
                 if start > end {
@@ -43,6 +44,16 @@ fn main() {
             } else {
                 eprintln!("{}", "Please specify either -r or -s".yellow());
                 return;
+            };
+
+            // Resolve the host to an IP once, so the parallel scan below does
+            // not issue a DNS lookup for every single port.
+            let scan_host = match port::resolve_host(&host) {
+                Some(ip) => ip.to_string(),
+                None => {
+                    eprintln!("{}", format!("Could not resolve host: {}", host).red());
+                    return;
+                }
             };
 
             let total_ports = ports.len();
@@ -66,10 +77,10 @@ fn main() {
             let opened_ports = Arc::new(Mutex::new(Vec::new()));
 
             ports.into_par_iter().for_each(|port| {
-                if let Some(open_port) = port::scan_port(host.clone(), port) {
-                    if let Ok(mut guard) = opened_ports.lock() {
-                        guard.push(open_port);
-                    }
+                if let Some(open_port) = port::scan_port(scan_host.clone(), port)
+                    && let Ok(mut guard) = opened_ports.lock()
+                {
+                    guard.push(open_port);
                 }
                 pb.inc(1);
             });
@@ -80,7 +91,11 @@ fn main() {
             opened.sort();
 
             if !opened.is_empty() {
-                println!("\n-- {} for {} --\n", "Opened ports".green(), host.bright_yellow());
+                println!(
+                    "\n-- {} for {} --\n",
+                    "Opened ports".green(),
+                    host.bright_yellow()
+                );
                 for port in &*opened {
                     println!("{}:{}", host.bright_cyan(), port.to_string().bright_green());
                 }
@@ -90,7 +105,11 @@ fn main() {
 
             println!("\n##### {} #####\n", "Game Over".bright_red());
         }
-        Args::AddressScan { subnet, target, range } => {
+        Args::AddressScan {
+            subnet,
+            target,
+            range,
+        } => {
             let available_ips: Vec<Ipv4Addr> = if let Some(subnet_str) = subnet {
                 match parse_subnet(&subnet_str) {
                     Ok(network) => {
@@ -122,10 +141,7 @@ fn main() {
                     }
                 }
             } else if let Some(range_vec) = range {
-                if range_vec.len() != 2 {
-                    eprintln!("{}", "Range requires two IP addresses".yellow());
-                    return;
-                }
+                // clap enforces exactly two values via `num_args = 2`.
                 match (parse_ipv4(&range_vec[0]), parse_ipv4(&range_vec[1])) {
                     (Ok(start), Ok(end)) => {
                         println!(
@@ -159,4 +175,3 @@ fn main() {
         }
     }
 }
-

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -1,9 +1,9 @@
-use std::net::{TcpStream, SocketAddr, IpAddr, Ipv4Addr};
-use std::time::Duration;
-use std::sync::{Arc, Mutex};
-use ipnetwork::IpNetwork;
 use indicatif::{ProgressBar, ProgressStyle};
+use ipnetwork::IpNetwork;
 use rayon::prelude::*;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 /// Scan a single IP address for availability
 ///
@@ -31,7 +31,7 @@ use rayon::prelude::*;
 pub fn scan_address(ip: Ipv4Addr, timeout: Option<Duration>) -> Option<Ipv4Addr> {
     match TcpStream::connect_timeout(
         &SocketAddr::new(IpAddr::V4(ip), 80),
-        timeout.unwrap_or(Duration::from_secs(1)),
+        timeout.unwrap_or(crate::scanner::port::CONNECT_TIMEOUT),
     ) {
         Ok(_) => Some(ip),
         Err(_) => None,
@@ -80,10 +80,10 @@ pub fn scan_subnet(subnet: IpNetwork) -> Vec<Ipv4Addr> {
             .into_par_iter()
             .for_each(|ip| {
                 let ipv4 = Ipv4Addr::from(ip);
-                if let Some(available_ip) = scan_address(ipv4, None) {
-                    if let Ok(mut guard) = available_ips.lock() {
-                        guard.push(available_ip);
-                    }
+                if let Some(available_ip) = scan_address(ipv4, None)
+                    && let Ok(mut guard) = available_ips.lock()
+                {
+                    guard.push(available_ip);
                 }
                 pb.inc(1);
             });
@@ -139,17 +139,15 @@ pub fn scan_ip_range(start: Ipv4Addr, end: Ipv4Addr) -> Vec<Ipv4Addr> {
 
     let available_ips = Arc::new(Mutex::new(Vec::new()));
 
-    (start_num..=end_num)
-        .into_par_iter()
-        .for_each(|ip| {
-            let ipv4 = Ipv4Addr::from(ip);
-            if let Some(available_ip) = scan_address(ipv4, None) {
-                if let Ok(mut guard) = available_ips.lock() {
-                    guard.push(available_ip);
-                }
-            }
-            pb.inc(1);
-        });
+    (start_num..=end_num).into_par_iter().for_each(|ip| {
+        let ipv4 = Ipv4Addr::from(ip);
+        if let Some(available_ip) = scan_address(ipv4, None)
+            && let Ok(mut guard) = available_ips.lock()
+        {
+            guard.push(available_ip);
+        }
+        pb.inc(1);
+    });
 
     pb.finish_with_message("Range scan completed");
     let mut result = available_ips.lock().unwrap();
@@ -164,7 +162,11 @@ mod tests {
 
     // Helper function to check if localhost is available
     fn is_localhost_available() -> bool {
-        scan_address("127.0.0.1".parse().unwrap(), Some(Duration::from_millis(100))).is_some()
+        scan_address(
+            "127.0.0.1".parse().unwrap(),
+            Some(Duration::from_millis(100)),
+        )
+        .is_some()
     }
 
     #[test]

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -6,5 +6,5 @@
 //! * `port` - Port scanning functionality
 //! * `address` - Address scanning functionality
 
-pub mod port;
 pub mod address;
+pub mod port;

--- a/src/scanner/port.rs
+++ b/src/scanner/port.rs
@@ -1,7 +1,41 @@
-use std::net::{TcpStream, SocketAddr, ToSocketAddrs};
+use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
-/// Check if a host is online by attempting to connect to port 80
+/// Default timeout for a single TCP connection attempt.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Resolve a host (numeric IP or DNS name) to its first IP address.
+///
+/// # Arguments
+///
+/// * `host` - The hostname or IP address to resolve
+///
+/// # Returns
+///
+/// * `Option<IpAddr>` - The first resolved address, or `None` if resolution fails
+///
+/// # Examples
+///
+/// ```
+/// use asphyxia::scanner::port::resolve_host;
+///
+/// assert!(resolve_host("127.0.0.1").is_some());
+/// assert!(resolve_host("").is_none());
+/// ```
+pub fn resolve_host(host: &str) -> Option<IpAddr> {
+    format!("{}:80", host)
+        .to_socket_addrs()
+        .ok()?
+        .next()
+        .map(|addr| addr.ip())
+}
+
+/// Check whether a host is reachable for scanning.
+///
+/// The host is resolved via DNS (numeric IPs and hostnames are both accepted).
+/// A host that resolves to at least one address is considered scannable — note
+/// that a closed port 80 does not make a host "offline", since the whole point
+/// of port scanning is to probe hosts whose open ports are unknown.
 ///
 /// # Arguments
 ///
@@ -9,7 +43,7 @@ use std::time::Duration;
 ///
 /// # Returns
 ///
-/// * `bool` - `true` if the host is online, `false` otherwise
+/// * `bool` - `true` if the host resolves to at least one address, `false` otherwise
 ///
 /// # Examples
 ///
@@ -17,23 +51,12 @@ use std::time::Duration;
 /// use asphyxia::scanner::port::is_online;
 ///
 /// if is_online("example.com") {
-///     println!("Host is online");
+///     println!("Host is reachable");
 /// }
 /// ```
 pub fn is_online(host: &str) -> bool {
-    match format!("{}:80", host).parse::<SocketAddr>() {
-        Ok(addr) => {
-            if TcpStream::connect_timeout(&addr, Duration::from_secs(2)).is_ok() {
-                return true;
-            }
-
-            match host.to_string().to_socket_addrs() {
-                Ok(mut iter) => iter.next().is_some(),
-                Err(_) => false,
-            }
-        }
-        Err(_) => false,
-    }
+    // A host that resolves to at least one address is considered scannable.
+    resolve_host(host).is_some()
 }
 
 /// Scan a specific port on a host
@@ -58,17 +81,9 @@ pub fn is_online(host: &str) -> bool {
 /// ```
 pub fn scan_port(host: String, port: u16) -> Option<u16> {
     let addr = format!("{}:{}", host, port);
-    match addr.to_socket_addrs() {
-        Ok(mut addrs) => {
-            if let Some(addr) = addrs.next() {
-                match TcpStream::connect_timeout(&addr, Duration::from_secs(2)) {
-                    Ok(_) => Some(port),
-                    Err(_) => None,
-                }
-            } else {
-                None
-            }
-        }
+    let socket_addr = addr.to_socket_addrs().ok()?.next()?;
+    match TcpStream::connect_timeout(&socket_addr, CONNECT_TIMEOUT) {
+        Ok(_) => Some(port),
         Err(_) => None,
     }
 }
@@ -88,5 +103,17 @@ mod tests {
     fn test_scan_port_failure() {
         let result = scan_port("127.0.0.1".to_string(), 1); // Non-existent port
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_is_online_numeric_ip() {
+        // A numeric IP always resolves, so it is considered scannable.
+        assert!(is_online("127.0.0.1"));
+    }
+
+    #[test]
+    fn test_is_online_invalid_host() {
+        // An empty host cannot be resolved.
+        assert!(!is_online(""));
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
-use std::net::Ipv4Addr;
 use ipnetwork::IpNetwork;
+use std::net::Ipv4Addr;
 
 /// Parse a comma-separated string of port numbers into a vector of u16
 ///
@@ -22,7 +22,10 @@ use ipnetwork::IpNetwork;
 /// ```
 pub fn parse_ports(s: &str) -> Result<Vec<u16>, String> {
     s.split(',')
-        .map(|p| p.parse::<u16>().map_err(|_| format!("Invalid port number: {}", p)))
+        .map(|p| {
+            p.parse::<u16>()
+                .map_err(|_| format!("Invalid port number: {}", p))
+        })
         .collect()
 }
 
@@ -71,7 +74,8 @@ pub fn parse_ipv4(ip: &str) -> Result<Ipv4Addr, String> {
 /// assert!(parse_subnet("2001:db8::/32").is_err()); // IPv6 not supported
 /// ```
 pub fn parse_subnet(subnet: &str) -> Result<IpNetwork, String> {
-    subnet.parse::<IpNetwork>()
+    subnet
+        .parse::<IpNetwork>()
         .map_err(|_| format!("Invalid subnet format: {}", subnet))
         .and_then(|network| {
             if network.is_ipv4() {


### PR DESCRIPTION
## Что сделано

Исправления по результатам ревью проекта.

### 🔴 Критичные
- **`is_online()`** — переписана логика резолва: DNS-имена теперь резолвятся корректно (раньше любой hostname сразу считался offline и порт-скан прерывался). Вынесён общий `resolve_host()`, поправлен docstring, добавлены тесты.
- **Релизный workflow** — убраны шаги download/upload артефактов для закомментированных таргетов (Linux arm64, Windows), из-за которых джоба релиза падала. Архивные `actions/create-release@v1` и `upload-release-asset@v1` заменены на `softprops/action-gh-release@v2`, добавлен `permissions: contents: write`, удалён мёртвый шаг `cargo-bundle-licenses`.

### 🟠 Серьёзные
- Добавлен **`.github/workflows/ci.yml`**: `fmt --check` + `clippy -D warnings` + build + test на PR и push в `main` (с кешем и concurrency).
- **Homebrew-формула**: заполнен `desc`, синхронизированы тег/версия (`TAG` для URL, `VERSION` без `v` для поля version), SHA считаются из реальных артефактов.

### 🟡 Качество кода
- 3× `collapsible_if` → let-chains; убраны лишние скобки в `use`; удалены 2 мёртвые проверки `len() != 2` (clap гарантирует через `num_args = 2`).
- Разовый DNS-резолв для порт-скана вместо лукапа на каждый порт.
- Единый таймаут `CONNECT_TIMEOUT` (2с) для сканера портов и адресов.
- Метаданные в `Cargo.toml` (license / description / repository / keywords / categories).
- `cargo fmt` по всему проекту.

### Сознательно отложено (фичи/спорное, не баги)
- Настройка таймаута и IPv6 из CLI.
- Пропуск network/broadcast в `scan_subnet` (ломается на `/31`–`/32`, стоит делать отдельно).
- Вынос дублирующегося кода прогресс-бара в хелпер.

## Проверки
Локально проходят: `cargo build --locked`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` (9 unit + 12 doc-тестов).