### PR TITLE
Release v0.2.0: multi-platform release, signed artifacts, Homebrew, README

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -68,6 +68,21 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
+      - name: Sign release archives
+        env:
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        run: |
+          for f in artifacts/asphyxia-*.zip; do
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$PASSPHRASE" \
+              --armor --detach-sign "$f"
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -76,7 +91,9 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          files: artifacts/asphyxia-*.zip
+          files: |
+            artifacts/asphyxia-*.zip
+            artifacts/asphyxia-*.zip.asc
 
   updatehomebrew:
     needs: create-release
@@ -85,7 +102,7 @@ jobs:
       - name: Checkout brew tap repo
         uses: actions/checkout@v4
         with:
-          repository: jtprogru/homebrew-asphyxia
+          repository: jtprogru/homebrew-tap
           ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
@@ -94,6 +111,14 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
 
       - name: Generate Formula
         run: |
@@ -148,8 +173,7 @@ jobs:
 
       - name: Commit and push formula
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          # Identity and commit signing are configured by the import-gpg step.
           git add Formula/asphyxia.rb
-          git commit -m "Update asphyxia to ${GITHUB_REF_NAME}" || echo "No changes to commit"
+          git commit -S -m "Update asphyxia to ${GITHUB_REF_NAME}" || echo "No changes to commit"
           git push origin main

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -10,30 +10,20 @@ permissions:
 
 jobs:
   build-and-release:
+    name: Build ${{ matrix.rust_target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            arch: x86_64
             rust_target: x86_64-unknown-linux-gnu
-          # - os: ubuntu-latest
-          #   arch: arm64
-          #   rust_target: aarch64-unknown-linux-gnu
-          - os: macos-latest
-            arch: x86_64
+          - os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+          - os: macos-13
             rust_target: x86_64-apple-darwin
           - os: macos-latest
-            arch: arm64
             rust_target: aarch64-apple-darwin
-          # - os: windows-latest
-          #   arch: x86_64
-          #   rust_target: x86_64-pc-windows-msvc
-          # Если нужно, раскомментируйте для Windows ARM64
-          # - os: windows-latest
-          #   arch: arm64
-          #   rust_target: aarch64-pc-windows-msvc
 
     steps:
       - name: Checkout repository
@@ -45,21 +35,24 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.rust_target }}
 
-      - name: Build project
-        run: |
-          cargo build --release --locked --target ${{ matrix.rust_target }}
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust_target }}
 
-      - name: Package binaries
+      - name: Build project
+        run: cargo build --release --locked --target ${{ matrix.rust_target }}
+
+      - name: Package binary
         shell: bash
         run: |
-          mkdir -p release_binaries
-          cp target/${{ matrix.rust_target }}/release/asphyxia release_binaries/
-          chmod +x release_binaries/asphyxia || true
-          cd release_binaries
-          zip ../asphyxia-${{ matrix.rust_target }}.zip asphyxia
-          cd ..
+          archive="asphyxia-${{ matrix.rust_target }}.zip"
+          mkdir -p dist
+          cp "target/${{ matrix.rust_target }}/release/asphyxia" dist/
+          chmod +x dist/asphyxia
+          (cd dist && zip "../$archive" asphyxia)
 
-      - name: Upload binaries as artifacts
+      - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.rust_target }}
@@ -82,6 +75,7 @@ jobs:
           name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
+          generate_release_notes: true
           files: artifacts/asphyxia-*.zip
 
   updatehomebrew:
@@ -95,7 +89,7 @@ jobs:
           ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
-      - name: Download macOS artifacts
+      - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -105,8 +99,15 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
-          SHA_X86_64=$(sha256sum artifacts/asphyxia-x86_64-apple-darwin.zip | awk '{print $1}')
-          SHA_ARM64=$(sha256sum artifacts/asphyxia-aarch64-apple-darwin.zip | awk '{print $1}')
+
+          sha() { sha256sum "artifacts/$1" | awk '{print $1}'; }
+          url() { echo "https://github.com/jtprogru/asphyxia/releases/download/${TAG}/$1"; }
+
+          MAC_X86="asphyxia-x86_64-apple-darwin.zip"
+          MAC_ARM="asphyxia-aarch64-apple-darwin.zip"
+          LINUX_X86="asphyxia-x86_64-unknown-linux-gnu.zip"
+          LINUX_ARM="asphyxia-aarch64-unknown-linux-gnu.zip"
+
           mkdir -p Formula
           cat <<EOL > Formula/asphyxia.rb
           class Asphyxia < Formula
@@ -114,13 +115,26 @@ jobs:
             homepage "https://github.com/jtprogru/asphyxia"
             version "${VERSION}"
 
-            if OS.mac? && Hardware::CPU.intel?
-              url "https://github.com/jtprogru/asphyxia/releases/download/${TAG}/asphyxia-x86_64-apple-darwin.zip"
-              sha256 "${SHA_X86_64}"
+            on_macos do
+              on_intel do
+                url "$(url "$MAC_X86")"
+                sha256 "$(sha "$MAC_X86")"
+              end
+              on_arm do
+                url "$(url "$MAC_ARM")"
+                sha256 "$(sha "$MAC_ARM")"
+              end
             end
-            if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/jtprogru/asphyxia/releases/download/${TAG}/asphyxia-aarch64-apple-darwin.zip"
-              sha256 "${SHA_ARM64}"
+
+            on_linux do
+              on_intel do
+                url "$(url "$LINUX_X86")"
+                sha256 "$(sha "$LINUX_X86")"
+              end
+              on_arm do
+                url "$(url "$LINUX_ARM")"
+                sha256 "$(sha "$LINUX_ARM")"
+              end
             end
 
             def install
@@ -128,6 +142,9 @@ jobs:
             end
           end
           EOL
+
+          echo "----- Generated Formula/asphyxia.rb -----"
+          cat Formula/asphyxia.rb
 
       - name: Commit and push formula
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "asphyxia"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asphyxia"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = [
     "Mikhail Savin <jtprogru@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 ### Homebrew (macOS & Linux)
 
 ```bash
-brew tap jtprogru/asphyxia
-brew install jtprogru/asphyxia/asphyxia
+brew tap jtprogru/tap
+brew install jtprogru/tap/asphyxia
 ```
 
-The formula is published automatically to the [jtprogru/homebrew-asphyxia](https://github.com/jtprogru/homebrew-asphyxia) tap on every release and supports macOS (Intel & Apple Silicon) and Linux (x86_64 & arm64).
+The formula is published automatically to the [jtprogru/homebrew-tap](https://github.com/jtprogru/homebrew-tap) tap on every release and supports macOS (Intel & Apple Silicon) and Linux (x86_64 & arm64).
 
 ### Prebuilt binaries
 
@@ -36,6 +36,12 @@ Download the archive for your platform from the [latest release](https://github.
 
 - Linux: `x86_64`, `aarch64`
 - macOS: `x86_64`, `aarch64` (Apple Silicon)
+
+Each archive is shipped with a detached GPG signature (`.asc`). After importing the signing key you can verify an archive with:
+
+```bash
+gpg --verify asphyxia-<target>.zip.asc asphyxia-<target>.zip
+```
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -1,66 +1,120 @@
 # Asphyxia
 
+[![CI](https://github.com/jtprogru/asphyxia/actions/workflows/ci.yml/badge.svg)](https://github.com/jtprogru/asphyxia/actions/workflows/ci.yml)
 [![Rust Release](https://github.com/jtprogru/asphyxia/actions/workflows/rust-release.yml/badge.svg)](https://github.com/jtprogru/asphyxia/actions/workflows/rust-release.yml)
 
-A powerful network utility tool written in Rust.
+A fast and efficient network scanner written in Rust.
 
 ## Description
 
-Asphyxia is a command-line network utility tool that provides efficient network operations and analysis capabilities. Built with performance and reliability in mind, it leverages Rust's powerful features to deliver fast and secure network operations.
+Asphyxia is a command-line network scanner that helps you discover open ports on a host and find reachable hosts on a network. It runs scans in parallel for speed and shows live progress while it works.
 
 ## Features
 
-- Command-line interface with intuitive argument parsing
-- Parallel processing capabilities
-- Progress indication for long-running operations
-- Network address handling and manipulation
-- Colorized terminal output
+- **Port scanning** — scan a range of ports or a specific comma-separated list on a target host.
+- **Address scanning** — check a single IP, scan an IP range, or scan an entire subnet (CIDR).
+- **Parallel execution** — scans run concurrently via [rayon](https://crates.io/crates/rayon).
+- **Live progress bars** — long-running scans show real-time progress.
+- **Colorized output** — readable, colored terminal output.
+
+> Note: Asphyxia currently works with IPv4 targets.
 
 ## Installation
 
-### Prerequisites
+### Homebrew (macOS & Linux)
 
-- Rust and Cargo (latest stable version recommended)
-- Git
+```bash
+brew tap jtprogru/asphyxia
+brew install jtprogru/asphyxia/asphyxia
+```
 
-### Building from Source
+The formula is published automatically to the [jtprogru/homebrew-asphyxia](https://github.com/jtprogru/homebrew-asphyxia) tap on every release and supports macOS (Intel & Apple Silicon) and Linux (x86_64 & arm64).
 
-1. Clone the repository:
+### Prebuilt binaries
 
-    ```bash
-    git clone https://github.com/jtprogru/asphyxia.git
-    cd asphyxia
-    ```
+Download the archive for your platform from the [latest release](https://github.com/jtprogru/asphyxia/releases/latest), unzip it, and place the `asphyxia` binary somewhere on your `PATH`. Builds are provided for:
 
-2. Build the project:
+- Linux: `x86_64`, `aarch64`
+- macOS: `x86_64`, `aarch64` (Apple Silicon)
 
-    ```bash
-    cargo build --release
-    ```
+### Building from source
 
-The compiled binary will be available at `target/release/asphyxia`
+Requires a recent stable Rust toolchain (the project uses the 2024 edition).
+
+```bash
+git clone https://github.com/jtprogru/asphyxia.git
+cd asphyxia
+cargo build --release
+```
+
+The compiled binary will be available at `target/release/asphyxia`.
 
 ## Usage
 
-```bash
-# Basic usage
-./target/release/asphyxia [OPTIONS]
+Asphyxia exposes two subcommands: `ps` (port scan) and `as` (address scan).
 
-# For more information
-./target/release/asphyxia --help
+```bash
+asphyxia --help        # general help
+asphyxia ps --help     # port scan options
+asphyxia as --help     # address scan options
 ```
+
+### Port scanning (`ps`)
+
+```bash
+# Scan a range of ports (start end)
+asphyxia ps -t example.com -r 80 443
+
+# Scan specific ports (comma-separated)
+asphyxia ps -t example.com -s 22,80,443,8080
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t, --host <HOST>` | Target host (hostname or IP) |
+| `-r, --range <START> <END>` | Scan an inclusive range of ports |
+| `-s, --specific <PORTS>` | Scan specific comma-separated ports |
+
+### Address scanning (`as`)
+
+```bash
+# Scan a subnet in CIDR notation
+asphyxia as -s 192.168.1.0/24
+
+# Scan a single IP address
+asphyxia as -t 192.168.1.1
+
+# Scan a range of IP addresses (start end)
+asphyxia as -r 192.168.1.1 192.168.1.20
+```
+
+| Flag | Description |
+|------|-------------|
+| `-s, --subnet <SUBNET>` | Scan a subnet, e.g. `192.168.1.0/24` |
+| `-t, --target <IP>` | Scan a single IPv4 address |
+| `-r, --range <START> <END>` | Scan an inclusive range of IPv4 addresses |
 
 ## Dependencies
 
-- [clap](https://crates.io/crates/clap) - Command line argument parsing
-- [rayon](https://crates.io/crates/rayon) - Parallel computing
-- [indicatif](https://crates.io/crates/indicatif) - Progress bars and spinners
-- [owo-colors](https://crates.io/crates/owo-colors) - Terminal colors
-- [ipnetwork](https://crates.io/crates/ipnetwork) - IP network address handling
+- [clap](https://crates.io/crates/clap) — command-line argument parsing
+- [rayon](https://crates.io/crates/rayon) — parallel computing
+- [indicatif](https://crates.io/crates/indicatif) — progress bars and spinners
+- [owo-colors](https://crates.io/crates/owo-colors) — terminal colors
+- [ipnetwork](https://crates.io/crates/ipnetwork) — IP network address handling
+
+## Development
+
+```bash
+cargo fmt --all          # format
+cargo clippy --all-targets -- -D warnings   # lint
+cargo test               # run unit and doc tests
+```
+
+CI runs formatting, Clippy (warnings denied), build, and tests on every pull request and push to `main`.
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the [MIT License](LICENSE).
 
 ## Contributing
 


### PR DESCRIPTION
## Что сделано

### Версия
- Поднята версия `0.1.0 → 0.2.0` (Cargo.toml + Cargo.lock).

### Релиз собирается и публикуется везде (issue #2)
Матрица сборки на **нативных раннерах** (без кросс-компиляции):
- Linux: `x86_64` (`ubuntu-latest`), `aarch64` (`ubuntu-24.04-arm`)
- macOS: `x86_64` (`macos-13`), `aarch64` (`macos-latest`)

Релиз создаётся через `softprops/action-gh-release` с glob по артефактам (заменил архивные `create-release`/`upload-release-asset`). Windows исключён по требованию.

### Homebrew (полная реализация issue #2)
- Формула генерируется целиком: `on_macos`/`on_linux` × `on_intel`/`on_arm` с реальными SHA256.
- Пушится в реальный tap `jtprogru/homebrew-tap` на каждом релизе.
- Установка: `brew tap jtprogru/tap && brew install jtprogru/tap/asphyxia`.

### GPG-подпись
- Каждый архив релиза подписывается detached-подписью `.asc` и прикладывается к Release.
- Коммит формулы в tap подписывается (`git commit -S`); ключ импортируется через `crazy-max/ghaction-import-gpg`, identity берётся из UID ключа.
- Задействованы секреты `HOMEBREW_TAP_TOKEN`, `GPG_PRIVATE_KEY`, `PASSPHRASE`.

### README
- Переписан: фичи, установка (Homebrew / готовые бинарники + проверка подписи / сборка из исходников), использование `ps`/`as` с таблицами флагов, раздел разработки, бейдж CI.

## Проверки
- Локально зелёные: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (9 unit + 12 doc).
- Native release-сборка `aarch64-apple-darwin` v0.2.0 проходит, бинарь запускается.
- YAML обоих workflow валиден.
- Полный прогон релиза возможен только на пуше тега (локально GitHub Actions не запускался).

## Требует внимания при первом релизе
- Email в UID GPG-ключа должен быть подтверждён в аккаунте, а публичный ключ загружен в GitHub — иначе подписанный коммит будет «Unverified».
- Раннеры `ubuntu-24.04-arm` доступны для публичных репозиториев.