### PR TITLE
Add machine-readable JSON/JSONL output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "asphyxia"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -72,6 +72,8 @@ dependencies = [
  "owo-colors",
  "predicates",
  "rayon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -264,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +465,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asphyxia"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = [
     "Mikhail Savin <jtprogru@gmail.com>"
@@ -21,6 +21,8 @@ rayon = "1.10.0"
 indicatif = "0.17.11"
 owo-colors = "4.2.1"
 ipnetwork = "0.20.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 - **Parallel execution** — scans run concurrently via [rayon](https://crates.io/crates/rayon), with tunable concurrency (`--concurrency`) for large subnet scans.
 - **Live progress bars** — long-running scans show real-time progress.
 - **Colorized output** — readable, colored terminal output.
+- **Machine-readable output** — emit results as JSON or JSON Lines with `--output` for piping into other tools.
 
 > Note: IPv6 subnet and range scans are capped at 65 536 addresses (e.g. a `/112`), since larger IPv6 spaces are impractical to walk exhaustively.
 
@@ -106,6 +107,7 @@ asphyxia ps -t 2001:db8::1 -s 22,80,443 --timeout 500
 | `-s, --specific <PORTS>` | Scan specific comma-separated ports |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
+| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, or `jsonl` |
 
 ### Address scanning (`as`)
 
@@ -132,8 +134,28 @@ asphyxia as -s 192.168.1.0/24 --timeout 300
 | `-r, --range <START> <END>` | Scan an inclusive range of IPs (start and end must share the same family) |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
+| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, or `jsonl` |
 
 > Host availability is inferred from a TCP probe: a host counts as up when it either accepts the connection or actively refuses it (a closed port still proves the host answered). A host that times out or is unreachable is reported as down — so a live host behind a firewall that silently drops packets may appear offline. This is an unprivileged, best-effort check, not an ICMP ping.
+
+### Machine-readable output (`--output`)
+
+By default Asphyxia prints a colorized, human-friendly report. Pass `--output json` or `--output jsonl` (alias `-o`) to emit structured results instead — for example to feed a network map, a coverage analyzer, or any downstream tool. Each result is a self-contained record with the fields `ip`, `port` (omitted for address scans), `proto`, `latency_ms`, and `status`.
+
+```bash
+# One JSON object per open port, on its own line (JSON Lines)
+asphyxia ps -t example.com -s 22,80,443 -o jsonl
+# {"ip":"93.184.216.34","port":80,"proto":"tcp","latency_ms":12,"status":"open"}
+
+# A single JSON array of available hosts
+asphyxia as -s 192.168.1.0/24 -o json
+```
+
+Records are written to stdout; the progress bar and any errors go to stderr, so a consumer reading stdout sees only the data stream. An empty result is `[]` for `json` and no output for `jsonl`. Pipe straight into `jq`:
+
+```bash
+asphyxia ps -t example.com -r 1 1024 -o jsonl 2>/dev/null | jq -c 'select(.port == 443)'
+```
 
 ## Performance
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
 
+use crate::output::OutputFormat;
+
 /// Command line arguments for the Asphyxia network scanner
 #[derive(Parser, Debug)]
 #[command(
@@ -32,6 +34,10 @@ Examples:
 
   # Raise concurrency to speed up a large subnet scan
   asphyxia as -s 10.0.0.0/22 --concurrency 512
+
+  # Emit machine-readable output for a pipeline (text | json | jsonl)
+  asphyxia ps -t example.com -s 22,80,443 -o jsonl
+  asphyxia as -s 10.0.0.0/24 -o json
 
 Required arguments:
   For port scanning (ps):
@@ -70,6 +76,10 @@ pub enum Args {
         /// Maximum number of concurrent connection attempts
         #[arg(short = 'c', long, value_name = "N", default_value_t = 256)]
         concurrency: usize,
+
+        /// Output format
+        #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
+        output: OutputFormat,
     },
     /// Address scanning command
     #[command(name = "as", about = "Start address scanning")]
@@ -93,6 +103,10 @@ pub enum Args {
         /// Maximum number of concurrent connection attempts
         #[arg(short = 'c', long, value_name = "N", default_value_t = 256)]
         concurrency: usize,
+
+        /// Output format
+        #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
+        output: OutputFormat,
     },
 }
 
@@ -104,6 +118,13 @@ impl Args {
             Args::PortScan { concurrency, .. } | Args::AddressScan { concurrency, .. } => {
                 *concurrency
             }
+        }
+    }
+
+    /// The requested output format, regardless of which subcommand was invoked.
+    pub fn output_format(&self) -> OutputFormat {
+        match self {
+            Args::PortScan { output, .. } | Args::AddressScan { output, .. } => *output,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,18 +21,18 @@
 //!
 //! ### Basic Port Scanning
 //! ```no_run
-//! use asphyxia::{scan_port, scan_address};
+//! use asphyxia::scan_port;
 //!
 //! // Scan a single port (default timeout)
-//! if let Some(port) = scan_port("example.com".to_string(), 80, None) {
-//!     println!("Port 80 is open");
+//! if let Some(hit) = scan_port("example.com".to_string(), 80, None) {
+//!     println!("Port {} is open ({} ms)", hit.port, hit.latency.as_millis());
 //! }
 //!
 //! // Scan multiple ports
 //! let ports = vec![80, 443, 8080];
 //! for port in ports {
-//!     if let Some(_) = scan_port("example.com".to_string(), port, None) {
-//!         println!("Port {} is open", port);
+//!     if let Some(hit) = scan_port("example.com".to_string(), port, None) {
+//!         println!("Port {} is open", hit.port);
 //!     }
 //! }
 //! ```
@@ -91,10 +91,12 @@
 //! scanning functions which are optimized for scanning multiple hosts.
 
 pub mod cli;
+pub mod output;
 pub mod scanner;
 pub mod utils;
 
-pub use scanner::address::{scan_address, scan_ip_range, scan_subnet};
+pub use output::{OutputFormat, ScanRecord};
+pub use scanner::address::{HostHit, scan_address, scan_ip_range, scan_subnet};
 /// Re-export commonly used types and functions
-pub use scanner::port::{is_resolvable, resolve_host, scan_port};
+pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port};
 pub use utils::{init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::net::IpAddr;
 use std::time::Duration;
 
 use clap::Parser;
@@ -6,10 +5,12 @@ use owo_colors::OwoColorize;
 use rayon::prelude::*;
 
 mod cli;
+mod output;
 mod scanner;
 mod utils;
 
 use cli::Args;
+use output::{OutputFormat, ScanRecord, print_json, print_jsonl};
 use scanner::{address, port};
 use utils::{init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar};
 
@@ -18,6 +19,8 @@ fn main() {
 
     // Size the global rayon pool for I/O-bound scanning before any scan runs.
     init_scan_pool(args.concurrency());
+
+    let format = args.output_format();
 
     match args {
         Args::PortScan {
@@ -69,15 +72,17 @@ fn main() {
 
             let total_ports = ports.len();
 
-            println!(
-                "\n##### {} scanning ports on host: {} #####\n",
-                "Started".bright_blue(),
-                host.bright_green()
-            );
+            if format == OutputFormat::Text {
+                println!(
+                    "\n##### {} scanning ports on host: {} #####\n",
+                    "Started".bright_blue(),
+                    host.bright_green()
+                );
+            }
 
             let pb = progress_bar(total_ports as u64, "ports scanned");
 
-            let mut opened: Vec<u16> = ports
+            let mut opened: Vec<port::PortHit> = ports
                 .into_par_iter()
                 .filter_map(|port| {
                     let open_port = port::scan_port(scan_host.clone(), port, timeout);
@@ -88,22 +93,47 @@ fn main() {
 
             pb.finish_with_message("Scan completed");
 
-            opened.sort();
+            opened.sort_by_key(|hit| hit.port);
 
-            if !opened.is_empty() {
-                println!(
-                    "\n-- {} for {} --\n",
-                    "Opened ports".green(),
-                    host.bright_yellow()
-                );
-                for port in &opened {
-                    println!("{}:{}", host.bright_cyan(), port.to_string().bright_green());
+            match format {
+                OutputFormat::Text => {
+                    if !opened.is_empty() {
+                        println!(
+                            "\n-- {} for {} --\n",
+                            "Opened ports".green(),
+                            host.bright_yellow()
+                        );
+                        for hit in &opened {
+                            println!(
+                                "{}:{}",
+                                host.bright_cyan(),
+                                hit.port.to_string().bright_green()
+                            );
+                        }
+                    } else {
+                        println!("\n{}", "No open ports found 😕".yellow());
+                    }
+
+                    println!("\n##### {} #####\n", "Game Over".bright_red());
                 }
-            } else {
-                println!("\n{}", "No open ports found 😕".yellow());
+                OutputFormat::Json | OutputFormat::Jsonl => {
+                    let records: Vec<ScanRecord> = opened
+                        .iter()
+                        .map(|hit| ScanRecord {
+                            ip: scan_host.clone(),
+                            port: Some(hit.port),
+                            proto: "tcp",
+                            latency_ms: hit.latency.as_millis(),
+                            status: "open",
+                        })
+                        .collect();
+                    if format == OutputFormat::Json {
+                        print_json(&records);
+                    } else {
+                        print_jsonl(&records);
+                    }
+                }
             }
-
-            println!("\n##### {} #####\n", "Game Over".bright_red());
         }
         Args::AddressScan {
             subnet,
@@ -114,14 +144,16 @@ fn main() {
         } => {
             let timeout = Some(Duration::from_millis(timeout));
 
-            let available_ips: Vec<IpAddr> = if let Some(subnet_str) = subnet {
+            let available: Vec<address::HostHit> = if let Some(subnet_str) = subnet {
                 match parse_subnet(&subnet_str) {
                     Ok(network) => {
-                        println!(
-                            "\n##### {} scanning subnet: {} #####\n",
-                            "Started".bright_blue(),
-                            subnet_str.as_str().bright_green()
-                        );
+                        if format == OutputFormat::Text {
+                            println!(
+                                "\n##### {} scanning subnet: {} #####\n",
+                                "Started".bright_blue(),
+                                subnet_str.as_str().bright_green()
+                            );
+                        }
                         address::scan_subnet(network, timeout)
                     }
                     Err(e) => {
@@ -132,11 +164,13 @@ fn main() {
             } else if let Some(target_str) = target {
                 match parse_ip(&target_str) {
                     Ok(ip) => {
-                        println!(
-                            "\n##### {} scanning target: {} #####\n",
-                            "Started".bright_blue(),
-                            target_str.as_str().bright_green()
-                        );
+                        if format == OutputFormat::Text {
+                            println!(
+                                "\n##### {} scanning target: {} #####\n",
+                                "Started".bright_blue(),
+                                target_str.as_str().bright_green()
+                            );
+                        }
                         address::scan_address(ip, timeout).into_iter().collect()
                     }
                     Err(e) => {
@@ -148,12 +182,14 @@ fn main() {
                 // clap enforces exactly two values via `num_args = 2`.
                 match (parse_ip(&range_vec[0]), parse_ip(&range_vec[1])) {
                     (Ok(start), Ok(end)) => {
-                        println!(
-                            "\n##### {} scanning range: {} - {} #####\n",
-                            "Started".bright_blue(),
-                            range_vec[0].as_str().bright_green(),
-                            range_vec[1].as_str().bright_green()
-                        );
+                        if format == OutputFormat::Text {
+                            println!(
+                                "\n##### {} scanning range: {} - {} #####\n",
+                                "Started".bright_blue(),
+                                range_vec[0].as_str().bright_green(),
+                                range_vec[1].as_str().bright_green()
+                            );
+                        }
                         address::scan_ip_range(start, end, timeout)
                     }
                     (Err(e), _) | (_, Err(e)) => {
@@ -166,16 +202,37 @@ fn main() {
                 return;
             };
 
-            if !available_ips.is_empty() {
-                println!("\n-- {} --\n", "Available hosts".green());
-                for ip in available_ips {
-                    println!("{}", ip.to_string().bright_green());
-                }
-            } else {
-                println!("\n{}", "No available hosts found 😕".yellow());
-            }
+            match format {
+                OutputFormat::Text => {
+                    if !available.is_empty() {
+                        println!("\n-- {} --\n", "Available hosts".green());
+                        for hit in &available {
+                            println!("{}", hit.ip.to_string().bright_green());
+                        }
+                    } else {
+                        println!("\n{}", "No available hosts found 😕".yellow());
+                    }
 
-            println!("\n##### {} #####\n", "Game Over".bright_red());
+                    println!("\n##### {} #####\n", "Game Over".bright_red());
+                }
+                OutputFormat::Json | OutputFormat::Jsonl => {
+                    let records: Vec<ScanRecord> = available
+                        .iter()
+                        .map(|hit| ScanRecord {
+                            ip: hit.ip.to_string(),
+                            port: None,
+                            proto: "tcp",
+                            latency_ms: hit.latency.as_millis(),
+                            status: "up",
+                        })
+                        .collect();
+                    if format == OutputFormat::Json {
+                        print_json(&records);
+                    } else {
+                        print_jsonl(&records);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,57 @@
+//! Machine-readable output for scan results.
+//!
+//! By default the scanner prints a human-friendly, colorized report. The
+//! formats here turn each result into a structured [`ScanRecord`] so the
+//! scanner can act as the first stage of a pipeline (e.g. feeding a network
+//! map or coverage analyzer) rather than only being read by a human.
+//!
+//! Machine output goes to stdout, one self-contained stream:
+//! [`OutputFormat::Json`] emits a single JSON array, [`OutputFormat::Jsonl`]
+//! emits one JSON object per line (JSON Lines). The progress bar stays on
+//! stderr, so a consumer reading stdout sees only records.
+
+use clap::ValueEnum;
+use serde::Serialize;
+
+/// How scan results are rendered to stdout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-friendly, colorized report (default).
+    Text,
+    /// A single JSON array of [`ScanRecord`].
+    Json,
+    /// JSON Lines: one [`ScanRecord`] object per line.
+    Jsonl,
+}
+
+/// One scan result in a normalized, machine-readable shape.
+///
+/// The fields are a superset of what a port scan and an address scan each
+/// produce: `port` is present for port scans and omitted for host discovery.
+#[derive(Debug, Serialize)]
+pub struct ScanRecord {
+    /// Target address (resolved IP for a port scan, host IP for discovery).
+    pub ip: String,
+    /// Open port; omitted for address (host-availability) scans.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    /// Transport protocol of the probe.
+    pub proto: &'static str,
+    /// Wall-clock latency of the probe, in milliseconds.
+    pub latency_ms: u128,
+    /// `"open"` for an open port, `"up"` for an available host.
+    pub status: &'static str,
+}
+
+/// Print all records as a single JSON array. An empty slice prints `[]`.
+pub fn print_json(records: &[ScanRecord]) {
+    // Serializing a slice of serializable records cannot fail.
+    println!("{}", serde_json::to_string(records).unwrap());
+}
+
+/// Print one JSON object per line (JSON Lines). An empty slice prints nothing.
+pub fn print_jsonl(records: &[ScanRecord]) {
+    for record in records {
+        println!("{}", serde_json::to_string(record).unwrap());
+    }
+}

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -2,9 +2,19 @@ use ipnetwork::IpNetwork;
 use rayon::prelude::*;
 use std::io::ErrorKind;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::utils::progress_bar;
+
+/// An available host together with how long the availability probe took.
+///
+/// The latency is the wall-clock time the [`PROBE_PORT`] connection spent
+/// before succeeding or being refused/reset — a rough proxy for distance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostHit {
+    pub ip: IpAddr,
+    pub latency: Duration,
+}
 
 /// TCP port used to probe a host when checking availability.
 ///
@@ -41,7 +51,7 @@ pub const MAX_IPV6_HOSTS: u128 = 1 << 16; // 65_536 addresses (e.g. a /112)
 ///
 /// # Returns
 ///
-/// * `Option<IpAddr>` - The IP address if the host is up, `None` otherwise
+/// * `Option<HostHit>` - The host and its probe latency if up, `None` otherwise
 ///
 /// # Examples
 ///
@@ -51,15 +61,19 @@ pub const MAX_IPV6_HOSTS: u128 = 1 << 16; // 65_536 addresses (e.g. a /112)
 /// use std::time::Duration;
 ///
 /// let ip: IpAddr = "192.168.1.1".parse().unwrap();
-/// if let Some(available_ip) = scan_address(ip, Some(Duration::from_millis(500))) {
-///     println!("Host {} is up", available_ip);
+/// if let Some(hit) = scan_address(ip, Some(Duration::from_millis(500))) {
+///     println!("Host {} is up ({} ms)", hit.ip, hit.latency.as_millis());
 /// }
 /// ```
-pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<IpAddr> {
+pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<HostHit> {
     let timeout = timeout.unwrap_or(crate::scanner::port::CONNECT_TIMEOUT);
+    let start = Instant::now();
     match TcpStream::connect_timeout(&SocketAddr::new(ip, PROBE_PORT), timeout) {
         // Port is open: the host is unambiguously up.
-        Ok(_) => Some(ip),
+        Ok(_) => Some(HostHit {
+            ip,
+            latency: start.elapsed(),
+        }),
         // The host replied with a reset — it is up, the port is just closed.
         Err(e)
             if matches!(
@@ -67,7 +81,10 @@ pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<IpAddr> {
                 ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset
             ) =>
         {
-            Some(ip)
+            Some(HostHit {
+                ip,
+                latency: start.elapsed(),
+            })
         }
         // Timeout, unreachable, or anything else: treat the host as down.
         Err(_) => None,
@@ -80,13 +97,13 @@ pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<IpAddr> {
 /// This is the shared engine behind subnet and range scans: it owns the
 /// progress bar and the parallel fan-out so callers only have to describe
 /// which addresses to probe.
-fn scan_all<I>(addrs: I, total: u64, timeout: Option<Duration>, finish_msg: &str) -> Vec<IpAddr>
+fn scan_all<I>(addrs: I, total: u64, timeout: Option<Duration>, finish_msg: &str) -> Vec<HostHit>
 where
     I: ParallelIterator<Item = IpAddr>,
 {
     let pb = progress_bar(total, "addresses scanned");
 
-    let mut result: Vec<IpAddr> = addrs
+    let mut result: Vec<HostHit> = addrs
         .filter_map(|ip| {
             let available = scan_address(ip, timeout);
             pb.inc(1);
@@ -95,7 +112,7 @@ where
         .collect();
 
     pb.finish_with_message(finish_msg.to_string());
-    result.sort();
+    result.sort_by_key(|h| h.ip);
     result
 }
 
@@ -112,7 +129,7 @@ where
 ///
 /// # Returns
 ///
-/// * `Vec<IpAddr>` - A vector of available IP addresses
+/// * `Vec<HostHit>` - A vector of available hosts with their probe latency
 ///
 /// # Examples
 ///
@@ -124,7 +141,7 @@ where
 /// let available_hosts = scan_subnet(subnet, None);
 /// println!("Found {} available hosts", available_hosts.len());
 /// ```
-pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<IpAddr> {
+pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<HostHit> {
     match (subnet.network(), subnet.broadcast()) {
         (IpAddr::V4(network), IpAddr::V4(broadcast)) => {
             let start = u32::from(network);
@@ -168,7 +185,7 @@ pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<IpAddr> 
 ///
 /// # Returns
 ///
-/// * `Vec<IpAddr>` - A vector of available IP addresses
+/// * `Vec<HostHit>` - A vector of available hosts with their probe latency
 ///
 /// # Examples
 ///
@@ -181,7 +198,7 @@ pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<IpAddr> 
 /// let available_hosts = scan_ip_range(start, end, None);
 /// println!("Found {} available hosts", available_hosts.len());
 /// ```
-pub fn scan_ip_range(start: IpAddr, end: IpAddr, timeout: Option<Duration>) -> Vec<IpAddr> {
+pub fn scan_ip_range(start: IpAddr, end: IpAddr, timeout: Option<Duration>) -> Vec<HostHit> {
     match (start, end) {
         (IpAddr::V4(start), IpAddr::V4(end)) => {
             let start = u32::from(start);
@@ -267,7 +284,8 @@ mod tests {
         }
 
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
-        assert!(scan_address(ip, TEST_TIMEOUT).is_some());
+        let hit = scan_address(ip, TEST_TIMEOUT).expect("localhost should be up");
+        assert_eq!(hit.ip, ip);
     }
 
     #[test]
@@ -290,8 +308,9 @@ mod tests {
         let results = scan_subnet(subnet, TEST_TIMEOUT);
 
         // Verify that results contain localhost and are sorted
-        assert!(results.contains(&"127.0.0.1".parse::<IpAddr>().unwrap()));
-        assert!(results.windows(2).all(|w| w[0] <= w[1]));
+        let localhost: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(results.iter().any(|h| h.ip == localhost));
+        assert!(results.windows(2).all(|w| w[0].ip <= w[1].ip));
     }
 
     #[test]
@@ -308,8 +327,9 @@ mod tests {
         let results = scan_ip_range(start, end, TEST_TIMEOUT);
 
         // Verify that results contain localhost and are sorted
-        assert!(results.contains(&"127.0.0.1".parse::<IpAddr>().unwrap()));
-        assert!(results.windows(2).all(|w| w[0] <= w[1]));
+        let localhost: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(results.iter().any(|h| h.ip == localhost));
+        assert!(results.windows(2).all(|w| w[0].ip <= w[1].ip));
     }
 
     #[test]

--- a/src/scanner/port.rs
+++ b/src/scanner/port.rs
@@ -1,8 +1,18 @@
 use std::net::{IpAddr, Ipv6Addr, TcpStream, ToSocketAddrs};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Default timeout for a single TCP connection attempt.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// An open port together with how long the TCP handshake took.
+///
+/// The latency is the wall-clock time spent in [`TcpStream::connect_timeout`]
+/// for the successful connection — a rough proxy for how close the target is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortHit {
+    pub port: u16,
+    pub latency: Duration,
+}
 
 /// Format a `host:port` authority, wrapping bare IPv6 literals in brackets so
 /// that they round-trip through [`ToSocketAddrs`] (e.g. `[::1]:80`).
@@ -79,21 +89,25 @@ pub fn is_resolvable(host: &str) -> bool {
 ///
 /// # Returns
 ///
-/// * `Option<u16>` - The port number if it's open, `None` otherwise
+/// * `Option<PortHit>` - The open port and its connect latency, or `None` if closed
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use asphyxia::scanner::port::scan_port;
 ///
-/// if let Some(port) = scan_port("example.com".to_string(), 80, None) {
-///     println!("Port {} is open", port);
+/// if let Some(hit) = scan_port("example.com".to_string(), 80, None) {
+///     println!("Port {} is open ({} ms)", hit.port, hit.latency.as_millis());
 /// }
 /// ```
-pub fn scan_port(host: String, port: u16, timeout: Option<Duration>) -> Option<u16> {
+pub fn scan_port(host: String, port: u16, timeout: Option<Duration>) -> Option<PortHit> {
     let socket_addr = host_port(&host, port).to_socket_addrs().ok()?.next()?;
+    let start = Instant::now();
     match TcpStream::connect_timeout(&socket_addr, timeout.unwrap_or(CONNECT_TIMEOUT)) {
-        Ok(_) => Some(port),
+        Ok(_) => Some(PortHit {
+            port,
+            latency: start.elapsed(),
+        }),
         Err(_) => None,
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -113,3 +113,53 @@ fn concurrency_flag_rejects_non_numeric() {
         .assert()
         .failure();
 }
+
+#[test]
+fn port_scan_json_with_no_open_ports_emits_empty_array() {
+    // Port 1 on loopback is closed, so the machine output is an empty JSON
+    // array and none of the human-facing banners leak onto stdout.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn port_scan_jsonl_with_no_open_ports_emits_nothing() {
+    // JSON Lines prints one object per result; with no open ports stdout is
+    // empty (zero lines), keeping the stream clean for a consumer.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "jsonl"])
+        .assert()
+        .success()
+        .stdout(predicate::eq(""));
+}
+
+#[test]
+fn address_scan_json_with_no_hosts_emits_empty_array() {
+    asphyxia()
+        .args(["as", "-t", "192.168.255.255", "-o", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn output_flag_rejects_unknown_format() {
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "bogus"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn text_output_remains_the_default() {
+    // Without `-o`, the human-facing banner is still printed: this pins the
+    // backwards-compatible default behaviour.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Game Over"));
+}


### PR DESCRIPTION
## Что и зачем

`asphyxia` сегодня печатает результат только как раскрашенный текст, поэтому её вывод нельзя скормить ни одному downstream-инструменту. В плане экспресс-аудита observability (`o11y-audit-plan.md`, Часть II §1) сканер вписан как первый кирпич конвейера карты сетей с явной границей: **сканер остаётся быстрым и «тупым», но отдаёт машиночитаемый поток**, а вся «умная» часть (классификация сервисов, TLS, проба `/metrics`, граф, k8s, TSDB, отчёты) живёт в отдельном слое. Этот PR закрывает ровно тот разрыв — структурированный вывод — не затаскивая «мозги» в сканер.

## Изменения

- **Новый флаг `-o, --output text|json|jsonl`** на обеих сабкомандах (`ps`, `as`), по умолчанию `text` — текущее поведение не меняется.
  - `json` → один JSON-массив; `jsonl` → один объект на строку (JSON Lines).
  - Записи идут на stdout; баннеры подавляются, прогресс-бар и ошибки — на stderr, так что consumer читает чистый поток данных. Пустой результат: `[]` для `json`, ноль строк для `jsonl`.
- **Захват латентности** TCP-connect: `scan_port`/`scan_address` теперь возвращают `PortHit`/`HostHit` (порт/ip + latency), выводится как `latency_ms`.
- **Формат записи**: `{ip, port?, proto, latency_ms, status}` — надмножество контракта из документа (`first_bytes`/banner-граб намеренно опущен как «мозги», вне объёма). `port` опускается для address-сканов.
- Bump `0.4.0` → `0.5.0`; добавлены `serde`/`serde_json`; формат описан в README.

Вне объёма (по согласованию): классификация сервисов, TLS, HTTP-проба, banner/`first_bytes`, rate-limit, allowlist подсетей, граф/k8s/TSDB/отчёты.

## Проверка

- `make ci` зелёный: fmt-check, clippy (`-D warnings`), build, тесты.
- 14 lib unit + 16 CLI integration (+5 новых, детерминированные, без сети) + 13 doctests.
- Ручная проверка:
  - `asphyxia ps -t 127.0.0.1 -s 22,80,443 -o jsonl 2>/dev/null` — по объекту на открытый порт.
  - `asphyxia as -s 127.0.0.0/30 -o json 2>/dev/null | jq .` — валидный массив.
  - `asphyxia ps -t 127.0.0.1 -s 1 -o json` → `[]`.
  - Текстовый режим без `-o` — без изменений.