### PR TITLE
Add CSV and greppable output formats and --output-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 - **Parallel execution** — scans run concurrently via [rayon](https://crates.io/crates/rayon), with tunable concurrency (`--concurrency`) for large subnet scans.
 - **Live progress bars** — long-running scans show real-time progress.
 - **Colorized output** — readable, colored terminal output.
-- **Machine-readable output** — emit results as JSON or JSON Lines with `--output` for piping into other tools.
+- **Machine-readable output** — emit results as JSON, JSON Lines, CSV, or greppable text with `--output`, and write them straight to a file with `--output-file`, for piping into other tools.
 
 > Note: IPv6 subnet and range scans are capped at 65 536 addresses (e.g. a `/112`), since larger IPv6 spaces are impractical to walk exhaustively.
 
@@ -127,7 +127,8 @@ Exactly one target source is required — either `-t/--host` or `--stdin` — an
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
-| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, or `jsonl` |
+| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
+| `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
 ### Address scanning (`as`)
 
@@ -154,13 +155,14 @@ asphyxia as -s 192.168.1.0/24 --timeout 300
 | `-r, --range <START> <END>` | Scan an inclusive range of IPs (start and end must share the same family) |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
-| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, or `jsonl` |
+| `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
+| `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
 > Host availability is inferred from a TCP probe: a host counts as up when it either accepts the connection or actively refuses it (a closed port still proves the host answered). A host that times out or is unreachable is reported as down — so a live host behind a firewall that silently drops packets may appear offline. This is an unprivileged, best-effort check, not an ICMP ping.
 
 ### Machine-readable output (`--output`)
 
-By default Asphyxia prints a colorized, human-friendly report. Pass `--output json` or `--output jsonl` (alias `-o`) to emit structured results instead — for example to feed a network map, a coverage analyzer, or any downstream tool. Each result is a self-contained record with the fields `ip`, `port` (omitted for address scans), `proto`, `latency_ms`, and `status`.
+By default Asphyxia prints a colorized, human-friendly report. Pass `--output` (alias `-o`) with one of `json`, `jsonl`, `csv`, or `grep` to emit structured results instead — for example to feed a network map, a spreadsheet, a ticket, or a downstream tool. Each result is a self-contained record with the fields `ip`, `port` (omitted/blank for address scans), `proto`, `latency_ms`, and `status`.
 
 ```bash
 # One JSON object per open port, on its own line (JSON Lines)
@@ -169,12 +171,24 @@ asphyxia ps -t example.com -s 22,80,443 -o jsonl
 
 # A single JSON array of available hosts
 asphyxia as -s 192.168.1.0/24 -o json
+
+# CSV with a header row (ip,port,proto,status,latency_ms)
+asphyxia ps -t example.com --top-ports 100 -o csv
+
+# Greppable, tab-separated columns for grep/awk/cut
+asphyxia ps -t example.com -s 22,80,443 -o grep
 ```
 
-Records are written to stdout; the progress bar and any errors go to stderr, so a consumer reading stdout sees only the data stream. An empty result is `[]` for `json` and no output for `jsonl`. Pipe straight into `jq`:
+Records are written to stdout; the progress bar and any errors go to stderr, so a consumer reading stdout sees only the data stream. An empty result is `[]` for `json`, a lone header for `csv`, and no output for `jsonl`/`grep`. Pipe straight into `jq`:
 
 ```bash
 asphyxia ps -t example.com -r 1 1024 -o jsonl 2>/dev/null | jq -c 'select(.port == 443)'
+```
+
+Use `--output-file <PATH>` (alias `--oF`) to write the machine-readable output to a file instead of stdout — handy for saving a scan while still watching the progress bar on the terminal:
+
+```bash
+asphyxia ps -t example.com --top-ports 1000 -o csv --output-file scan.csv
 ```
 
 ### Chaining discovery into port scanning (`--stdin`)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{ArgGroup, Parser};
 
 use crate::output::OutputFormat;
@@ -46,9 +48,12 @@ Examples:
   # Raise concurrency to speed up a large subnet scan
   asphyxia as -s 10.0.0.0/22 --concurrency 512
 
-  # Emit machine-readable output for a pipeline (text | json | jsonl)
+  # Emit machine-readable output for a pipeline (text | json | jsonl | csv | grep)
   asphyxia ps -t example.com -s 22,80,443 -o jsonl
   asphyxia as -s 10.0.0.0/24 -o json
+
+  # Save machine-readable output to a file instead of stdout
+  asphyxia ps -t example.com --top-ports 1000 -o csv --output-file scan.csv
 
 Required arguments:
   For port scanning (ps):
@@ -118,6 +123,10 @@ pub enum Args {
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
         output: OutputFormat,
+
+        /// Write machine-readable output to a file instead of stdout
+        #[arg(long = "output-file", visible_alias = "oF", value_name = "PATH")]
+        output_file: Option<PathBuf>,
     },
     /// Address scanning command
     #[command(name = "as", about = "Start address scanning")]
@@ -145,6 +154,10 @@ pub enum Args {
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
         output: OutputFormat,
+
+        /// Write machine-readable output to a file instead of stdout
+        #[arg(long = "output-file", visible_alias = "oF", value_name = "PATH")]
+        output_file: Option<PathBuf>,
     },
 }
 
@@ -163,6 +176,16 @@ impl Args {
     pub fn output_format(&self) -> OutputFormat {
         match self {
             Args::PortScan { output, .. } | Args::AddressScan { output, .. } => *output,
+        }
+    }
+
+    /// The file to write machine-readable output to, if any, regardless of
+    /// which subcommand was invoked.
+    pub fn output_file(&self) -> Option<&PathBuf> {
+        match self {
+            Args::PortScan { output_file, .. } | Args::AddressScan { output_file, .. } => {
+                output_file.as_ref()
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod output;
 pub mod scanner;
 pub mod utils;
 
-pub use output::{OutputFormat, ScanRecord};
+pub use output::{OutputFormat, ScanRecord, emit, render};
 pub use scanner::address::{HostHit, scan_address, scan_ip_range, scan_subnet};
 /// Re-export commonly used types and functions
 pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use owo_colors::OwoColorize;
 use rayon::prelude::*;
 
 use asphyxia::cli::Args;
-use asphyxia::output::{OutputFormat, ScanRecord, print_json, print_jsonl};
+use asphyxia::output::{OutputFormat, ScanRecord, emit};
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
 use asphyxia::scanner::{address, port};
 use asphyxia::utils::{
@@ -19,6 +19,7 @@ fn main() {
     init_scan_pool(args.concurrency());
 
     let format = args.output_format();
+    let output_file = args.output_file().cloned();
 
     match args {
         Args::PortScan {
@@ -174,7 +175,7 @@ fn main() {
 
                     println!("\n##### {} #####\n", "Game Over".bright_red());
                 }
-                OutputFormat::Json | OutputFormat::Jsonl => {
+                _ => {
                     let records: Vec<ScanRecord> = opened
                         .iter()
                         .map(|(i, hit)| ScanRecord {
@@ -185,10 +186,8 @@ fn main() {
                             status: "open",
                         })
                         .collect();
-                    if format == OutputFormat::Json {
-                        print_json(&records);
-                    } else {
-                        print_jsonl(&records);
+                    if let Err(e) = emit(&records, format, output_file.as_deref()) {
+                        eprintln!("{}", format!("Failed to write output: {}", e).red());
                     }
                 }
             }
@@ -273,7 +272,7 @@ fn main() {
 
                     println!("\n##### {} #####\n", "Game Over".bright_red());
                 }
-                OutputFormat::Json | OutputFormat::Jsonl => {
+                _ => {
                     let records: Vec<ScanRecord> = available
                         .iter()
                         .map(|hit| ScanRecord {
@@ -284,10 +283,8 @@ fn main() {
                             status: "up",
                         })
                         .collect();
-                    if format == OutputFormat::Json {
-                        print_json(&records);
-                    } else {
-                        print_jsonl(&records);
+                    if let Err(e) = emit(&records, format, output_file.as_deref()) {
+                        eprintln!("{}", format!("Failed to write output: {}", e).red());
                     }
                 }
             }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,15 +5,20 @@
 //! scanner can act as the first stage of a pipeline (e.g. feeding a network
 //! map or coverage analyzer) rather than only being read by a human.
 //!
-//! Machine output goes to stdout, one self-contained stream:
-//! [`OutputFormat::Json`] emits a single JSON array, [`OutputFormat::Jsonl`]
-//! emits one JSON object per line (JSON Lines). The progress bar stays on
-//! stderr, so a consumer reading stdout sees only records.
+//! Machine output is a single self-contained stream:
+//! [`OutputFormat::Json`] emits a JSON array, [`OutputFormat::Jsonl`] emits one
+//! JSON object per line, [`OutputFormat::Csv`] emits a header plus one row per
+//! result, and [`OutputFormat::Grep`] emits one whitespace-separated line per
+//! result for `grep`/`awk`. It normally goes to stdout — with the progress bar
+//! kept on stderr — but [`emit`] can redirect it to a file instead.
+
+use std::io::{self, Write};
+use std::path::Path;
 
 use clap::ValueEnum;
 use serde::Serialize;
 
-/// How scan results are rendered to stdout.
+/// How scan results are rendered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
     /// Human-friendly, colorized report (default).
@@ -22,6 +27,19 @@ pub enum OutputFormat {
     Json,
     /// JSON Lines: one [`ScanRecord`] object per line.
     Jsonl,
+    /// CSV with a header row (`ip,port,proto,status,latency_ms`).
+    Csv,
+    /// Greppable plain text: one tab-separated line per result.
+    Grep,
+}
+
+impl OutputFormat {
+    /// Whether this is a structured, machine-readable format (everything but
+    /// [`OutputFormat::Text`]). Machine formats are rendered by [`render`] and
+    /// can be written to a file with [`emit`].
+    pub fn is_machine(self) -> bool {
+        !matches!(self, OutputFormat::Text)
+    }
 }
 
 /// One scan result in a normalized, machine-readable shape.
@@ -43,15 +61,166 @@ pub struct ScanRecord {
     pub status: &'static str,
 }
 
+/// Render `records` in a machine-readable `format` into a single string.
+///
+/// The returned string is the complete output for the format, including any
+/// trailing newline. Passing [`OutputFormat::Text`] returns an empty string:
+/// the colorized human report is produced by the caller, not here.
+pub fn render(records: &[ScanRecord], format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Text => String::new(),
+        OutputFormat::Json => {
+            // Serializing a slice of serializable records cannot fail.
+            format!("{}\n", serde_json::to_string(records).unwrap())
+        }
+        OutputFormat::Jsonl => {
+            let mut out = String::new();
+            for record in records {
+                out.push_str(&serde_json::to_string(record).unwrap());
+                out.push('\n');
+            }
+            out
+        }
+        OutputFormat::Csv => render_csv(records),
+        OutputFormat::Grep => render_grep(records),
+    }
+}
+
+/// CSV with a fixed header. The `port` column is empty for host-discovery
+/// records, which have no port.
+fn render_csv(records: &[ScanRecord]) -> String {
+    let mut out = String::from("ip,port,proto,status,latency_ms\n");
+    for r in records {
+        let port = r.port.map(|p| p.to_string()).unwrap_or_default();
+        out.push_str(&format!(
+            "{},{},{},{},{}\n",
+            r.ip, port, r.proto, r.status, r.latency_ms
+        ));
+    }
+    out
+}
+
+/// Greppable plain text: one tab-separated line per result, no header, so it
+/// slots straight into `grep`/`awk`/`cut` pipelines. The port column is `-`
+/// for host-discovery records.
+fn render_grep(records: &[ScanRecord]) -> String {
+    let mut out = String::new();
+    for r in records {
+        let port = r
+            .port
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\n",
+            r.ip, port, r.proto, r.status, r.latency_ms
+        ));
+    }
+    out
+}
+
+/// Write `records` in `format` to `path` when given, otherwise to stdout.
+///
+/// Machine formats ([`OutputFormat::is_machine`]) are rendered via [`render`].
+/// [`OutputFormat::Text`] has no machine rendering, so it is a no-op here — the
+/// caller prints the human report directly.
+pub fn emit(records: &[ScanRecord], format: OutputFormat, path: Option<&Path>) -> io::Result<()> {
+    if !format.is_machine() {
+        return Ok(());
+    }
+    let rendered = render(records, format);
+    match path {
+        Some(path) => std::fs::write(path, rendered),
+        None => io::stdout().write_all(rendered.as_bytes()),
+    }
+}
+
 /// Print all records as a single JSON array. An empty slice prints `[]`.
 pub fn print_json(records: &[ScanRecord]) {
-    // Serializing a slice of serializable records cannot fail.
-    println!("{}", serde_json::to_string(records).unwrap());
+    print!("{}", render(records, OutputFormat::Json));
 }
 
 /// Print one JSON object per line (JSON Lines). An empty slice prints nothing.
 pub fn print_jsonl(records: &[ScanRecord]) {
-    for record in records {
-        println!("{}", serde_json::to_string(record).unwrap());
+    print!("{}", render(records, OutputFormat::Jsonl));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<ScanRecord> {
+        vec![
+            ScanRecord {
+                ip: "127.0.0.1".to_string(),
+                port: Some(80),
+                proto: "tcp",
+                latency_ms: 3,
+                status: "open",
+            },
+            ScanRecord {
+                ip: "10.0.0.5".to_string(),
+                port: None,
+                proto: "tcp",
+                latency_ms: 12,
+                status: "up",
+            },
+        ]
+    }
+
+    #[test]
+    fn csv_has_header_and_blank_port_for_host_records() {
+        let out = render(&sample(), OutputFormat::Csv);
+        let mut lines = out.lines();
+        assert_eq!(lines.next().unwrap(), "ip,port,proto,status,latency_ms");
+        assert_eq!(lines.next().unwrap(), "127.0.0.1,80,tcp,open,3");
+        // Host-discovery record has an empty port column.
+        assert_eq!(lines.next().unwrap(), "10.0.0.5,,tcp,up,12");
+    }
+
+    #[test]
+    fn empty_csv_still_has_header() {
+        assert_eq!(
+            render(&[], OutputFormat::Csv),
+            "ip,port,proto,status,latency_ms\n"
+        );
+    }
+
+    #[test]
+    fn grep_is_tab_separated_with_dash_for_missing_port() {
+        let out = render(&sample(), OutputFormat::Grep);
+        let mut lines = out.lines();
+        assert_eq!(lines.next().unwrap(), "127.0.0.1\t80\ttcp\topen\t3");
+        assert_eq!(lines.next().unwrap(), "10.0.0.5\t-\ttcp\tup\t12");
+    }
+
+    #[test]
+    fn json_and_jsonl_shapes_match_expectations() {
+        assert_eq!(render(&[], OutputFormat::Json), "[]\n");
+        let jsonl = render(&sample(), OutputFormat::Jsonl);
+        assert_eq!(jsonl.lines().count(), 2);
+        assert!(
+            jsonl
+                .lines()
+                .all(|l| l.starts_with('{') && l.ends_with('}'))
+        );
+    }
+
+    #[test]
+    fn emit_writes_machine_output_to_a_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("asphyxia-emit-test-{}.csv", std::process::id()));
+        emit(&sample(), OutputFormat::Csv, Some(&path)).expect("write should succeed");
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("ip,port,proto,status,latency_ms\n"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn emit_text_is_a_noop() {
+        // Text has no machine rendering; emit must not create a file.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("asphyxia-emit-text-{}.txt", std::process::id()));
+        emit(&sample(), OutputFormat::Text, Some(&path)).expect("no-op should succeed");
+        assert!(!path.exists());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -219,6 +219,53 @@ fn port_scan_jsonl_with_no_open_ports_emits_nothing() {
 }
 
 #[test]
+fn port_scan_csv_emits_header_even_with_no_open_ports() {
+    // CSV always carries its header row so downstream parsers have a schema.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("ip,port,proto,status,latency_ms\n"));
+}
+
+#[test]
+fn port_scan_grep_with_no_open_ports_emits_nothing() {
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "grep"])
+        .assert()
+        .success()
+        .stdout(predicate::eq(""));
+}
+
+#[test]
+fn output_file_writes_machine_output_and_keeps_stdout_clean() {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-cli-out-{}.csv", std::process::id()));
+    let path_str = path.to_str().unwrap();
+
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1",
+            "-o",
+            "csv",
+            "--output-file",
+            path_str,
+        ])
+        .assert()
+        .success()
+        // Machine output went to the file, not stdout.
+        .stdout(predicate::eq(""));
+
+    let contents = std::fs::read_to_string(&path).expect("output file should exist");
+    assert!(contents.starts_with("ip,port,proto,status,latency_ms\n"));
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn address_scan_json_with_no_hosts_emits_empty_array() {
     asphyxia()
         .args(["as", "-t", "192.168.255.255", "-o", "json"])


### PR DESCRIPTION
## What

Closes #18.

Extends machine-readable output beyond JSON/JSONL and adds file output:

- `-o csv` — CSV with a header row `ip,port,proto,status,latency_ms` (the `port` column is blank for host-discovery records).
- `-o grep` — greppable, tab-separated columns with no header, so it slots straight into `grep`/`awk`/`cut`.
- `--output-file <PATH>` (alias `--oF`) — write the machine output to a file instead of stdout, keeping the progress bar on the terminal.

## Implementation

- `src/output/mod.rs`: two new `OutputFormat` variants (`Csv`, `Grep`), a reusable `render(records, format) -> String`, and `emit(records, format, path)` that writes to a file or stdout. `is_machine()` distinguishes structured formats from the human `text` report.
- `src/main.rs`: both scan arms now build records and call `emit`, reporting a clear error if the file write fails.
- `src/cli/mod.rs`: `--output-file` on both subcommands.

## Tests

- Unit tests for CSV header/blank-port, empty-CSV header, grep tab layout, JSON/JSONL shape, and `emit` file write + text no-op.
- CLI tests: CSV header with no open ports, empty grep output, and `--output-file` writing to disk while stdout stays clean.

## Docs

README features, usage, flag tables, and CLI `--help` updated.