### PR TITLE
Add --retries to re-probe on no answer for lossy networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Exactly one target source is required — either `-t/--host` or `--stdin` — an
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
+| `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
@@ -155,6 +156,7 @@ asphyxia as -s 192.168.1.0/24 --timeout 300
 | `-r, --range <START> <END>` | Scan an inclusive range of IPs (start and end must share the same family) |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
+| `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
@@ -216,6 +218,7 @@ To tune a scan:
 
 - **`--concurrency`** — raise it to finish large subnets faster (e.g. `--concurrency 512` for a `/22`); lower it if you want a gentler scan. Capped at 1024.
 - **`--timeout`** — on a responsive LAN a shorter timeout (e.g. `--timeout 500`) makes unreachable hosts give up much sooner.
+- **`--retries`** — on a lossy network (Wi-Fi, VPN, distant hosts) a dropped SYN makes an open port or live host look closed/down. A small value like `--retries 1` or `--retries 2` re-probes only when a probe got *no answer* (timeout/unreachable); a port that actively refuses the connection has already answered, so it is never retried and closed-port scans stay fast.
 
 For example, a `/24` with the defaults completes in roughly one timeout window instead of serially walking every address.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,6 +48,9 @@ Examples:
   # Raise concurrency to speed up a large subnet scan
   asphyxia as -s 10.0.0.0/22 --concurrency 512
 
+  # Retry probes on a lossy network to cut false negatives (refused ports are not retried)
+  asphyxia ps -t example.com --top-ports 1000 --retries 2
+
   # Emit machine-readable output for a pipeline (text | json | jsonl | csv | grep)
   asphyxia ps -t example.com -s 22,80,443 -o jsonl
   asphyxia as -s 10.0.0.0/24 -o json
@@ -120,6 +123,10 @@ pub enum Args {
         #[arg(short = 'c', long, value_name = "N", default_value_t = 256)]
         concurrency: usize,
 
+        /// Extra retries per probe on no answer (timeout); refused ports are final
+        #[arg(long, value_name = "N", default_value_t = 0)]
+        retries: u32,
+
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
         output: OutputFormat,
@@ -150,6 +157,10 @@ pub enum Args {
         /// Maximum number of concurrent connection attempts
         #[arg(short = 'c', long, value_name = "N", default_value_t = 256)]
         concurrency: usize,
+
+        /// Extra retries per probe on no answer (timeout); refused ports are final
+        #[arg(long, value_name = "N", default_value_t = 0)]
+        retries: u32,
 
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
@@ -186,6 +197,14 @@ impl Args {
             Args::PortScan { output_file, .. } | Args::AddressScan { output_file, .. } => {
                 output_file.as_ref()
             }
+        }
+    }
+
+    /// The number of extra retries per probe, regardless of which subcommand
+    /// was invoked.
+    pub fn retries(&self) -> u32 {
+        match self {
+            Args::PortScan { retries, .. } | Args::AddressScan { retries, .. } => *retries,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,9 +96,12 @@ pub mod scanner;
 pub mod utils;
 
 pub use output::{OutputFormat, ScanRecord, emit, render};
-pub use scanner::address::{HostHit, scan_address, scan_ip_range, scan_subnet};
+pub use scanner::address::{
+    HostHit, scan_address, scan_address_with_retries, scan_ip_range, scan_ip_range_with_retries,
+    scan_subnet, scan_subnet_with_retries,
+};
 /// Re-export commonly used types and functions
-pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port};
+pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};
 pub use utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_stdin,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
 
     let format = args.output_format();
     let output_file = args.output_file().cloned();
+    let retries = args.retries();
 
     match args {
         Args::PortScan {
@@ -139,7 +140,8 @@ fn main() {
             let mut opened: Vec<(usize, port::PortHit)> = jobs
                 .into_par_iter()
                 .filter_map(|(i, port)| {
-                    let hit = port::scan_port(resolved[i].1.clone(), port, timeout);
+                    let hit =
+                        port::scan_port_with_retries(resolved[i].1.clone(), port, timeout, retries);
                     pb.inc(1);
                     hit.map(|hit| (i, hit))
                 })
@@ -211,7 +213,7 @@ fn main() {
                                 subnet_str.as_str().bright_green()
                             );
                         }
-                        address::scan_subnet(network, timeout)
+                        address::scan_subnet_with_retries(network, timeout, retries)
                     }
                     Err(e) => {
                         eprintln!("{}", e.red());
@@ -228,7 +230,9 @@ fn main() {
                                 target_str.as_str().bright_green()
                             );
                         }
-                        address::scan_address(ip, timeout).into_iter().collect()
+                        address::scan_address_with_retries(ip, timeout, retries)
+                            .into_iter()
+                            .collect()
                     }
                     Err(e) => {
                         eprintln!("{}", e.red());
@@ -247,7 +251,7 @@ fn main() {
                                 range_vec[1].as_str().bright_green()
                             );
                         }
-                        address::scan_ip_range(start, end, timeout)
+                        address::scan_ip_range_with_retries(start, end, timeout, retries)
                     }
                     (Err(e), _) | (_, Err(e)) => {
                         eprintln!("{}", e.red());

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -66,7 +66,47 @@ pub const MAX_IPV6_HOSTS: u128 = 1 << 16; // 65_536 addresses (e.g. a /112)
 /// }
 /// ```
 pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<HostHit> {
+    scan_address_with_retries(ip, timeout, 0)
+}
+
+/// Scan a single IP for availability, retrying up to `retries` extra times when
+/// a probe gets no answer (timeout/unreachable).
+///
+/// On a lossy network a dropped probe makes a live host look down; a small
+/// `retries` value trades a little time for fewer false negatives. A host that
+/// answers (open, or refused/reset) is decided on the first probe and never
+/// retried. `retries == 0` is a single attempt, identical to [`scan_address`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use asphyxia::scanner::address::scan_address_with_retries;
+/// use std::net::IpAddr;
+/// use std::time::Duration;
+///
+/// let ip: IpAddr = "192.168.1.1".parse().unwrap();
+/// if let Some(hit) = scan_address_with_retries(ip, Some(Duration::from_millis(500)), 2) {
+///     println!("Host {} is up ({} ms)", hit.ip, hit.latency.as_millis());
+/// }
+/// ```
+pub fn scan_address_with_retries(
+    ip: IpAddr,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Option<HostHit> {
     let timeout = timeout.unwrap_or(crate::scanner::port::CONNECT_TIMEOUT);
+    for _ in 0..=retries {
+        if let Some(hit) = probe_address(ip, timeout) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
+/// Make a single availability probe. Returns `Some` when the host answers
+/// (open, or refused/reset) and `None` on silence (timeout/unreachable) — the
+/// only outcome worth retrying.
+fn probe_address(ip: IpAddr, timeout: Duration) -> Option<HostHit> {
     let start = Instant::now();
     match TcpStream::connect_timeout(&SocketAddr::new(ip, PROBE_PORT), timeout) {
         // Port is open: the host is unambiguously up.
@@ -86,7 +126,7 @@ pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<HostHit> {
                 latency: start.elapsed(),
             })
         }
-        // Timeout, unreachable, or anything else: treat the host as down.
+        // Timeout, unreachable, or anything else: no answer.
         Err(_) => None,
     }
 }
@@ -96,8 +136,15 @@ pub fn scan_address(ip: IpAddr, timeout: Option<Duration>) -> Option<HostHit> {
 ///
 /// This is the shared engine behind subnet and range scans: it owns the
 /// progress bar and the parallel fan-out so callers only have to describe
-/// which addresses to probe.
-fn scan_all<I>(addrs: I, total: u64, timeout: Option<Duration>, finish_msg: &str) -> Vec<HostHit>
+/// which addresses to probe. Each probe is retried up to `retries` extra times
+/// on silence (see [`scan_address_with_retries`]).
+fn scan_all<I>(
+    addrs: I,
+    total: u64,
+    timeout: Option<Duration>,
+    retries: u32,
+    finish_msg: &str,
+) -> Vec<HostHit>
 where
     I: ParallelIterator<Item = IpAddr>,
 {
@@ -105,7 +152,7 @@ where
 
     let mut result: Vec<HostHit> = addrs
         .filter_map(|ip| {
-            let available = scan_address(ip, timeout);
+            let available = scan_address_with_retries(ip, timeout, retries);
             pb.inc(1);
             available
         })
@@ -142,6 +189,18 @@ where
 /// println!("Found {} available hosts", available_hosts.len());
 /// ```
 pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<HostHit> {
+    scan_subnet_with_retries(subnet, timeout, 0)
+}
+
+/// Scan an entire subnet for available hosts, retrying each host up to
+/// `retries` extra times on silence (see [`scan_address_with_retries`]).
+///
+/// `retries == 0` is identical to [`scan_subnet`].
+pub fn scan_subnet_with_retries(
+    subnet: IpNetwork,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Vec<HostHit> {
     match (subnet.network(), subnet.broadcast()) {
         (IpAddr::V4(network), IpAddr::V4(broadcast)) => {
             let start = u32::from(network);
@@ -151,6 +210,7 @@ pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<HostHit>
                 (start..=end).into_par_iter().map(ipv4),
                 total,
                 timeout,
+                retries,
                 "Subnet scan completed",
             )
         }
@@ -161,6 +221,7 @@ pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<HostHit>
                     hosts.into_par_iter(),
                     total,
                     timeout,
+                    retries,
                     "Subnet scan completed",
                 )
             }
@@ -199,6 +260,19 @@ pub fn scan_subnet(subnet: IpNetwork, timeout: Option<Duration>) -> Vec<HostHit>
 /// println!("Found {} available hosts", available_hosts.len());
 /// ```
 pub fn scan_ip_range(start: IpAddr, end: IpAddr, timeout: Option<Duration>) -> Vec<HostHit> {
+    scan_ip_range_with_retries(start, end, timeout, 0)
+}
+
+/// Scan a range of IP addresses for available hosts, retrying each host up to
+/// `retries` extra times on silence (see [`scan_address_with_retries`]).
+///
+/// `retries == 0` is identical to [`scan_ip_range`].
+pub fn scan_ip_range_with_retries(
+    start: IpAddr,
+    end: IpAddr,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Vec<HostHit> {
     match (start, end) {
         (IpAddr::V4(start), IpAddr::V4(end)) => {
             let start = u32::from(start);
@@ -211,6 +285,7 @@ pub fn scan_ip_range(start: IpAddr, end: IpAddr, timeout: Option<Duration>) -> V
                 (start..=end).into_par_iter().map(ipv4),
                 total,
                 timeout,
+                retries,
                 "Range scan completed",
             )
         }
@@ -225,6 +300,7 @@ pub fn scan_ip_range(start: IpAddr, end: IpAddr, timeout: Option<Duration>) -> V
                         hosts.into_par_iter(),
                         total,
                         timeout,
+                        retries,
                         "Range scan completed",
                     )
                 }

--- a/src/scanner/port.rs
+++ b/src/scanner/port.rs
@@ -1,8 +1,42 @@
+use std::io::ErrorKind;
 use std::net::{IpAddr, Ipv6Addr, TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
 
 /// Default timeout for a single TCP connection attempt.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The outcome of a single connection attempt, classified so that retries only
+/// fire when it is worth retrying.
+///
+/// A lossy network can drop a lone SYN and make an open port look closed. But a
+/// host that actively *refuses* the connection has already answered — retrying
+/// that only wastes time. So we distinguish a definitive answer (open or
+/// refused/reset) from silence (timeout, unreachable), and retry only silence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Probe {
+    /// The handshake completed: the port is open. Carries the connect latency.
+    Open(Duration),
+    /// The host answered with a reset/refusal: the port is closed. Final.
+    Closed,
+    /// No answer (timeout, unreachable, …): worth retrying on a lossy network.
+    NoAnswer,
+}
+
+/// Run `probe` up to `retries` extra times, stopping as soon as it returns a
+/// definitive answer ([`Probe::Open`] or [`Probe::Closed`]). Only
+/// [`Probe::NoAnswer`] is retried. Returns the last outcome observed.
+///
+/// With `retries == 0` this is a single attempt — the original behaviour.
+fn with_retries<F: FnMut() -> Probe>(retries: u32, mut probe: F) -> Probe {
+    let mut outcome = Probe::NoAnswer;
+    for _ in 0..=retries {
+        outcome = probe();
+        if outcome != Probe::NoAnswer {
+            break;
+        }
+    }
+    outcome
+}
 
 /// An open port together with how long the TCP handshake took.
 ///
@@ -101,14 +135,61 @@ pub fn is_resolvable(host: &str) -> bool {
 /// }
 /// ```
 pub fn scan_port(host: String, port: u16, timeout: Option<Duration>) -> Option<PortHit> {
-    let socket_addr = host_port(&host, port).to_socket_addrs().ok()?.next()?;
+    scan_port_with_retries(host, port, timeout, 0)
+}
+
+/// Scan a specific port, retrying up to `retries` extra times when a probe gets
+/// no answer (timeout/unreachable).
+///
+/// On a lossy network a dropped SYN makes an open port look closed; a small
+/// `retries` value (e.g. 1–2) trades a little time for fewer false negatives. A
+/// refused/reset port is final and is never retried, so scans of closed ports
+/// stay fast. `retries == 0` is a single attempt, identical to [`scan_port`].
+///
+/// # Examples
+///
+/// ```no_run
+/// use asphyxia::scanner::port::scan_port_with_retries;
+///
+/// if let Some(hit) = scan_port_with_retries("example.com".to_string(), 80, None, 2) {
+///     println!("Port {} is open ({} ms)", hit.port, hit.latency.as_millis());
+/// }
+/// ```
+pub fn scan_port_with_retries(
+    host: String,
+    port: u16,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Option<PortHit> {
+    let timeout = timeout.unwrap_or(CONNECT_TIMEOUT);
+    match with_retries(retries, || probe_port(&host, port, timeout)) {
+        Probe::Open(latency) => Some(PortHit { port, latency }),
+        Probe::Closed | Probe::NoAnswer => None,
+    }
+}
+
+/// Make a single connection attempt to `host:port` and classify the outcome.
+fn probe_port(host: &str, port: u16, timeout: Duration) -> Probe {
+    let Some(socket_addr) = host_port(host, port)
+        .to_socket_addrs()
+        .ok()
+        .and_then(|mut addrs| addrs.next())
+    else {
+        // Unresolvable: retrying will not help, so treat it as a closed result.
+        return Probe::Closed;
+    };
     let start = Instant::now();
-    match TcpStream::connect_timeout(&socket_addr, timeout.unwrap_or(CONNECT_TIMEOUT)) {
-        Ok(_) => Some(PortHit {
-            port,
-            latency: start.elapsed(),
-        }),
-        Err(_) => None,
+    match TcpStream::connect_timeout(&socket_addr, timeout) {
+        Ok(_) => Probe::Open(start.elapsed()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset
+            ) =>
+        {
+            Probe::Closed
+        }
+        Err(_) => Probe::NoAnswer,
     }
 }
 
@@ -153,5 +234,64 @@ mod tests {
     fn test_host_port_ipv4_and_hostname_plain() {
         assert_eq!(host_port("127.0.0.1", 80), "127.0.0.1:80");
         assert_eq!(host_port("example.com", 8080), "example.com:8080");
+    }
+
+    #[test]
+    fn retries_stop_immediately_on_a_definitive_open() {
+        let mut calls = 0;
+        let outcome = with_retries(5, || {
+            calls += 1;
+            Probe::Open(Duration::from_millis(1))
+        });
+        assert_eq!(outcome, Probe::Open(Duration::from_millis(1)));
+        assert_eq!(calls, 1, "an open port must not be retried");
+    }
+
+    #[test]
+    fn retries_stop_immediately_on_a_definitive_closed() {
+        let mut calls = 0;
+        let outcome = with_retries(5, || {
+            calls += 1;
+            Probe::Closed
+        });
+        assert_eq!(outcome, Probe::Closed);
+        assert_eq!(calls, 1, "a refused/reset port must not be retried");
+    }
+
+    #[test]
+    fn no_answer_is_retried_exactly_retries_plus_one_times() {
+        let mut calls = 0;
+        let outcome = with_retries(3, || {
+            calls += 1;
+            Probe::NoAnswer
+        });
+        assert_eq!(outcome, Probe::NoAnswer);
+        // One initial attempt plus three retries.
+        assert_eq!(calls, 4);
+    }
+
+    #[test]
+    fn no_answer_then_open_succeeds_within_the_retry_budget() {
+        let mut calls = 0;
+        let outcome = with_retries(3, || {
+            calls += 1;
+            if calls < 3 {
+                Probe::NoAnswer
+            } else {
+                Probe::Open(Duration::from_millis(2))
+            }
+        });
+        assert_eq!(outcome, Probe::Open(Duration::from_millis(2)));
+        assert_eq!(calls, 3, "should stop on the first definitive answer");
+    }
+
+    #[test]
+    fn zero_retries_is_a_single_attempt() {
+        let mut calls = 0;
+        let _ = with_retries(0, || {
+            calls += 1;
+            Probe::NoAnswer
+        });
+        assert_eq!(calls, 1);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -189,6 +189,35 @@ fn concurrency_flag_is_accepted() {
 }
 
 #[test]
+fn retries_flag_is_accepted() {
+    // A closed port on loopback returns quickly (refused → no retry), so this
+    // stays fast even with retries requested.
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1",
+            "--retries",
+            "2",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn retries_flag_rejects_non_numeric() {
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "--retries", "lots"])
+        .assert()
+        .failure();
+}
+
+#[test]
 fn concurrency_flag_rejects_non_numeric() {
     asphyxia()
         .args(["as", "-s", "192.168.1.0/24", "--concurrency", "lots"])


### PR DESCRIPTION
## What

Closes #16.

Each port/host was probed exactly once, so on a lossy network (Wi-Fi, VPN, distant hosts) a dropped SYN made an open port or live host look closed/down. Adds `--retries <N>` (default `0`, on both `ps` and `as`) that re-probes on **no answer** only.

## Semantics

Each connection attempt is classified:

- **open** (handshake completed) — final, never retried.
- **closed** (`ConnectionRefused` / `ConnectionReset`) — the host answered, so this is final and never retried; closed-port scans stay fast.
- **no answer** (timeout / unreachable) — the only outcome retried, up to `N` extra times.

Default `0` preserves the current single-attempt behaviour exactly; a small value like `1`–`2` trades a little time for fewer false negatives.

## Implementation

- `src/scanner/port.rs`: a 3-state `Probe` classification, a generic `with_retries` loop, and `scan_port_with_retries`.
- `src/scanner/address.rs`: `probe_address` + `scan_address_with_retries`, threaded through `scan_all`, `scan_subnet_with_retries`, `scan_ip_range_with_retries`. Single-attempt public functions are kept as `retries == 0` wrappers.
- `src/cli/mod.rs` / `src/main.rs`: `--retries` option wired into both scans.

## Tests

- Unit tests for the retry loop: stops immediately on open/closed, retries no-answer exactly `retries + 1` times, stops on the first definitive answer, and `retries == 0` is a single attempt.
- CLI tests: `--retries` accepted, and rejected when non-numeric.

## Docs

README flag tables, tuning section, and CLI `--help` updated.