### PR TITLE
Improve host discovery: multi-port probe and -Pn

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ asphyxia as -r 192.168.1.1 192.168.1.20
 
 # Scan a subnet with a custom timeout
 asphyxia as -s 192.168.1.0/24 --timeout 300
+
+# Skip discovery and treat every address as up (like nmap -Pn)
+asphyxia as -s 192.168.1.0/24 --Pn -o jsonl | asphyxia ps --stdin --top-ports 100
 ```
 
 | Flag | Description |
@@ -154,13 +157,14 @@ asphyxia as -s 192.168.1.0/24 --timeout 300
 | `-s, --subnet <SUBNET>` | Scan a subnet, e.g. `192.168.1.0/24` or `2001:db8::/120` |
 | `-t, --target <IP>` | Scan a single IPv4 or IPv6 address |
 | `-r, --range <START> <END>` | Scan an inclusive range of IPs (start and end must share the same family) |
+| `--Pn` (`--skip-discovery`) | Skip host discovery and treat every target as up (like nmap `-Pn`) |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
-> Host availability is inferred from a TCP probe: a host counts as up when it either accepts the connection or actively refuses it (a closed port still proves the host answered). A host that times out or is unreachable is reported as down — so a live host behind a firewall that silently drops packets may appear offline. This is an unprivileged, best-effort check, not an ICMP ping.
+> Host availability is inferred from TCP probes across a small spread of common ports (80, 443, 22, 3389), tried in order until one answers: a host counts as up when any probed port either accepts the connection or actively refuses it (a closed port still proves the host answered). Probing more than one port finds live hosts that firewall port 80 but answer elsewhere. Only when every probed port times out or is unreachable is the host reported as down — so a host that silently drops packets on all of them may still appear offline. This is an unprivileged, best-effort check, not an ICMP ping; use `--Pn` to skip discovery entirely and treat every target as up.
 
 ### Machine-readable output (`--output`)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,6 +42,9 @@ Examples:
   # Scan a range of IP addresses
   asphyxia as -r 192.168.1.1 192.168.1.20
 
+  # Skip host discovery and treat every address as up (like nmap -Pn)
+  asphyxia as -s 192.168.1.0/24 --Pn
+
   # Use a custom connection timeout (milliseconds)
   asphyxia ps -t example.com -s 22,80,443 --timeout 500
 
@@ -74,6 +77,7 @@ Required arguments:
     -s, --subnet <SUBNET>        Scan a subnet (e.g., 192.168.1.0/24 or 2001:db8::/120)
     -t, --target <IP>            Scan a specific IP address (IPv4 or IPv6)
     -r, --range <START> <END>    Scan a range of IP addresses
+    --Pn                         Skip host discovery; treat every target as up
     --timeout <MS>               Connection timeout in milliseconds (default: 2000)
 "#
 )]
@@ -149,6 +153,10 @@ pub enum Args {
         /// Scan a range of IP addresses
         #[arg(short = 'r', long, num_args = 2, group = "scan_type")]
         range: Option<Vec<String>>,
+
+        /// Skip host discovery and treat every target as up (like nmap -Pn)
+        #[arg(long = "Pn", visible_alias = "skip-discovery")]
+        no_discovery: bool,
 
         /// Connection timeout in milliseconds
         #[arg(long, value_name = "MS", default_value_t = 2000)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ pub mod utils;
 
 pub use output::{OutputFormat, ScanRecord, emit, render};
 pub use scanner::address::{
-    HostHit, scan_address, scan_address_with_retries, scan_ip_range, scan_ip_range_with_retries,
-    scan_subnet, scan_subnet_with_retries,
+    HostHit, range_addresses, scan_address, scan_address_with_retries, scan_ip_range,
+    scan_ip_range_with_retries, scan_subnet, scan_subnet_with_retries, subnet_addresses,
 };
 /// Re-export commonly used types and functions
 pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::time::Duration;
 
 use clap::Parser;
@@ -11,6 +12,18 @@ use asphyxia::scanner::{address, port};
 use asphyxia::utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_stdin,
 };
+
+/// Mark every address as up without probing, for `-Pn` (skip discovery). The
+/// latency is zero since no probe was sent.
+fn all_up(addrs: Vec<IpAddr>) -> Vec<address::HostHit> {
+    addrs
+        .into_iter()
+        .map(|ip| address::HostHit {
+            ip,
+            latency: Duration::ZERO,
+        })
+        .collect()
+}
 
 fn main() {
     let args = Args::parse();
@@ -198,6 +211,7 @@ fn main() {
             subnet,
             target,
             range,
+            no_discovery,
             timeout,
             ..
         } => {
@@ -213,7 +227,11 @@ fn main() {
                                 subnet_str.as_str().bright_green()
                             );
                         }
-                        address::scan_subnet_with_retries(network, timeout, retries)
+                        if no_discovery {
+                            all_up(address::subnet_addresses(network))
+                        } else {
+                            address::scan_subnet_with_retries(network, timeout, retries)
+                        }
                     }
                     Err(e) => {
                         eprintln!("{}", e.red());
@@ -230,9 +248,13 @@ fn main() {
                                 target_str.as_str().bright_green()
                             );
                         }
-                        address::scan_address_with_retries(ip, timeout, retries)
-                            .into_iter()
-                            .collect()
+                        if no_discovery {
+                            all_up(vec![ip])
+                        } else {
+                            address::scan_address_with_retries(ip, timeout, retries)
+                                .into_iter()
+                                .collect()
+                        }
                     }
                     Err(e) => {
                         eprintln!("{}", e.red());
@@ -251,7 +273,11 @@ fn main() {
                                 range_vec[1].as_str().bright_green()
                             );
                         }
-                        address::scan_ip_range_with_retries(start, end, timeout, retries)
+                        if no_discovery {
+                            all_up(address::range_addresses(start, end))
+                        } else {
+                            address::scan_ip_range_with_retries(start, end, timeout, retries)
+                        }
                     }
                     (Err(e), _) | (_, Err(e)) => {
                         eprintln!("{}", e.red());

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -8,19 +8,23 @@ use crate::utils::progress_bar;
 
 /// An available host together with how long the availability probe took.
 ///
-/// The latency is the wall-clock time the [`PROBE_PORT`] connection spent
-/// before succeeding or being refused/reset — a rough proxy for distance.
+/// The latency is the wall-clock time the answering [`PROBE_PORTS`] connection
+/// spent before succeeding or being refused/reset — a rough proxy for distance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HostHit {
     pub ip: IpAddr,
     pub latency: Duration,
 }
 
-/// TCP port used to probe a host when checking availability.
+/// TCP ports used to probe a host when checking availability, tried in order
+/// until one answers.
 ///
-/// The port does not need to be open — see [`scan_address`] for how the
-/// connection outcome is interpreted.
-const PROBE_PORT: u16 = 80;
+/// A single probe port (say 80) misses a live host that firewalls that port but
+/// answers on another, so we probe a small spread of very common services and
+/// call the host up as soon as any of them answers. None of the ports needs to
+/// be *open* — see [`scan_address`] for how each connection outcome is
+/// interpreted.
+pub const PROBE_PORTS: [u16; 4] = [80, 443, 22, 3389];
 
 /// Upper bound on the number of addresses enumerated for a single subnet or
 /// range scan when the family is IPv6.
@@ -32,17 +36,19 @@ pub const MAX_IPV6_HOSTS: u128 = 1 << 16; // 65_536 addresses (e.g. a /112)
 
 /// Scan a single IP address for availability.
 ///
-/// Availability is inferred from how the host reacts to a TCP probe on
-/// [`PROBE_PORT`] rather than from whether that port happens to be open:
+/// Availability is inferred from how the host reacts to TCP probes across
+/// [`PROBE_PORTS`] rather than from whether any one port happens to be open. The
+/// host is up as soon as any probed port either:
 ///
-/// * the connection **succeeds** — the host is up (and the port is open); or
-/// * the connection is **refused/reset** — the host actively answered, so it
-///   is up even though the port is closed.
+/// * **succeeds** — the host is up (and that port is open); or
+/// * is **refused/reset** — the host actively answered, so it is up even though
+///   the port is closed.
 ///
-/// A timeout, "host unreachable", "network unreachable", or any other error is
-/// treated as down. This is a best-effort, unprivileged check: a live host
-/// behind a firewall that silently *drops* packets (rather than refusing them)
-/// is indistinguishable from one that is offline and will be reported as down.
+/// Only when *every* probe port is silent (timeout, "host unreachable",
+/// "network unreachable", …) is the host treated as down. This is a best-effort,
+/// unprivileged check: a live host behind a firewall that silently *drops*
+/// packets on all probed ports is indistinguishable from one that is offline and
+/// will be reported as down.
 ///
 /// # Arguments
 ///
@@ -103,12 +109,20 @@ pub fn scan_address_with_retries(
     None
 }
 
-/// Make a single availability probe. Returns `Some` when the host answers
-/// (open, or refused/reset) and `None` on silence (timeout/unreachable) — the
-/// only outcome worth retrying.
+/// Probe a host across [`PROBE_PORTS`] in order, returning `Some` as soon as any
+/// port answers (open, or refused/reset). Returns `None` only when *every* port
+/// is silent (timeout/unreachable) — the outcome worth retrying.
 fn probe_address(ip: IpAddr, timeout: Duration) -> Option<HostHit> {
+    PROBE_PORTS
+        .iter()
+        .find_map(|&port| probe_port(ip, port, timeout))
+}
+
+/// Make a single availability probe against one port. Returns `Some` when the
+/// host answers (open, or refused/reset) and `None` on silence.
+fn probe_port(ip: IpAddr, port: u16, timeout: Duration) -> Option<HostHit> {
     let start = Instant::now();
-    match TcpStream::connect_timeout(&SocketAddr::new(ip, PROBE_PORT), timeout) {
+    match TcpStream::connect_timeout(&SocketAddr::new(ip, port), timeout) {
         // Port is open: the host is unambiguously up.
         Ok(_) => Some(HostHit {
             ip,
@@ -339,6 +353,49 @@ fn ipv4(n: u32) -> IpAddr {
     IpAddr::V4(Ipv4Addr::from(n))
 }
 
+/// Enumerate every address in a subnet as a plain list, without probing.
+///
+/// This backs `-Pn` (skip host discovery): the caller marks every returned
+/// address as up. IPv4 subnets are enumerated in full; IPv6 subnets are subject
+/// to the same [`MAX_IPV6_HOSTS`] cap as a scan (a wider prefix warns and yields
+/// an empty list).
+pub fn subnet_addresses(subnet: IpNetwork) -> Vec<IpAddr> {
+    match (subnet.network(), subnet.broadcast()) {
+        (IpAddr::V4(network), IpAddr::V4(broadcast)) => {
+            let start = u32::from(network);
+            let end = u32::from(broadcast);
+            (start..=end).map(ipv4).collect()
+        }
+        (IpAddr::V6(network), IpAddr::V6(broadcast)) => {
+            ipv6_hosts(network, broadcast).unwrap_or_default()
+        }
+        // network() and broadcast() always share the subnet's family.
+        _ => Vec::new(),
+    }
+}
+
+/// Enumerate every address in an inclusive range as a plain list, without
+/// probing. Backs `-Pn` for range scans; mirrors [`subnet_addresses`].
+pub fn range_addresses(start: IpAddr, end: IpAddr) -> Vec<IpAddr> {
+    match (start, end) {
+        (IpAddr::V4(start), IpAddr::V4(end)) => {
+            let start = u32::from(start);
+            let end = u32::from(end);
+            if start > end {
+                return Vec::new();
+            }
+            (start..=end).map(ipv4).collect()
+        }
+        (IpAddr::V6(start), IpAddr::V6(end)) => {
+            if start > end {
+                return Vec::new();
+            }
+            ipv6_hosts(start, end).unwrap_or_default()
+        }
+        _ => Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -442,5 +499,43 @@ mod tests {
         } else {
             panic!("expected IPv6 network");
         }
+    }
+
+    #[test]
+    fn probe_reports_up_at_the_first_responding_port() {
+        // Bind a listener on an ephemeral port and probe it directly: the first
+        // (and only) port in the list answers, so the host is reported up.
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().unwrap().port();
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        let hit = probe_port(ip, port, Duration::from_millis(200));
+        assert!(hit.is_some(), "an open port should mark the host up");
+        assert_eq!(hit.unwrap().ip, ip);
+    }
+
+    #[test]
+    fn probe_ports_spans_more_than_just_port_80() {
+        // Regression guard for the multi-port discovery: a live host that only
+        // answers on a non-80 port must still be discoverable.
+        assert!(PROBE_PORTS.contains(&443));
+        assert!(PROBE_PORTS.len() > 1);
+    }
+
+    #[test]
+    fn subnet_addresses_enumerates_every_host_without_probing() {
+        let subnet = "127.0.0.0/30".parse::<IpNetwork>().unwrap();
+        let addrs = subnet_addresses(subnet);
+        // A /30 spans network..broadcast inclusive = 4 addresses.
+        assert_eq!(addrs.len(), 4);
+        assert!(addrs.contains(&"127.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn range_addresses_enumerates_inclusive_and_rejects_backwards() {
+        let start: IpAddr = "10.0.0.1".parse().unwrap();
+        let end: IpAddr = "10.0.0.5".parse().unwrap();
+        assert_eq!(range_addresses(start, end).len(), 5);
+        assert!(range_addresses(end, start).is_empty());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -296,11 +296,44 @@ fn output_file_writes_machine_output_and_keeps_stdout_clean() {
 
 #[test]
 fn address_scan_json_with_no_hosts_emits_empty_array() {
+    // A short timeout keeps this fast: discovery now probes several ports, each
+    // of which would otherwise block for the full default timeout.
     asphyxia()
-        .args(["as", "-t", "192.168.255.255", "-o", "json"])
+        .args([
+            "as",
+            "-t",
+            "192.168.255.255",
+            "--timeout",
+            "200",
+            "-o",
+            "json",
+        ])
         .assert()
         .success()
         .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn address_scan_pn_marks_target_up_without_probing() {
+    // -Pn skips discovery, so even an address that would never answer is
+    // reported up. No probe is sent, so this is instant regardless of timeout.
+    asphyxia()
+        .args(["as", "-t", "192.168.255.255", "--Pn", "-o", "jsonl"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"ip\":\"192.168.255.255\""))
+        .stdout(predicate::str::contains("\"status\":\"up\""));
+}
+
+#[test]
+fn address_scan_pn_marks_whole_range_up() {
+    asphyxia()
+        .args(["as", "-r", "10.10.10.1", "10.10.10.4", "--Pn", "-o", "json"])
+        .assert()
+        .success()
+        // All four addresses in the range are reported up without any probe.
+        .stdout(predicate::str::contains("10.10.10.1"))
+        .stdout(predicate::str::contains("10.10.10.4"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Closes #19.

Host discovery (`as`) probed only TCP 80, so a live host behind a firewall that drops 80 was reported down. This:

- **Probes multiple ports** — `80, 443, 22, 3389`, tried in order, calling the host up as soon as any answers (accept *or* refuse/reset). A host that only answers on 443 is now found.
- **Adds `--Pn`** (alias `--skip-discovery`, like nmap's `-Pn`) — skip discovery and treat every target as up. Handy to pipe a whole subnet straight into a port scan, or when discovery would hide a firewalled host.

ICMP echo probing is intentionally left out for now: it needs raw sockets / elevated privileges and is platform-specific; the multi-port TCP probe delivers the accuracy win unprivileged. `--Pn` covers the "don't let discovery hide a host" case.

## Implementation

- `src/scanner/address.rs`: `PROBE_PORTS` array; `probe_address` now iterates ports via `probe_port` and returns up on the first answer; new `subnet_addresses`/`range_addresses` enumerators (respecting `MAX_IPV6_HOSTS`) back `-Pn`.
- `src/cli/mod.rs` / `src/main.rs`: `--Pn` on the `as` subcommand; a live host list is built without probing when set.

## Tests

- Unit: probe reports up at the first responding port (real ephemeral listener), `PROBE_PORTS` spans more than 80, enumerators produce the right inclusive counts and reject backwards ranges.
- CLI: `--Pn` marks a never-answering target up, marks a whole range up, and the no-hosts test now uses a short timeout to stay fast under multi-port probing.

## Docs

README address-scanning section, availability note, flag tables, and CLI `--help` updated.