### PR TITLE
Add scan exclusions: hosts/CIDRs, ports, and CDN/WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ asphyxia ps -t example.com --top-ports 1000
 # Scan a named port set (web, mail, db, remote, windows)
 asphyxia ps -t example.com --ports web
 
+# Drop specific ports from the set, and spare known CDN/WAF targets (80/443 only)
+asphyxia ps -t example.com --top-ports 1000 --exclude-ports 9100,631
+asphyxia ps --stdin --top-ports 1000 --exclude-cdn < hosts.txt
+
 # Scan an IPv6 host with a shorter timeout
 asphyxia ps -t 2001:db8::1 -s 22,80,443 --timeout 500
 
@@ -125,6 +129,8 @@ Exactly one target source is required — either `-t/--host` or `--stdin` — an
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
 | `--top-ports <N>` | Scan the `N` most common TCP ports (frequency-ordered, up to 1000) |
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
+| `--exclude-ports <PORTS>` | Remove these comma-separated ports from the scan set |
+| `--exclude-cdn` | For known CDN/WAF targets, scan only 80 and 443 instead of the full set |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
@@ -150,6 +156,10 @@ asphyxia as -s 192.168.1.0/24 --timeout 300
 
 # Skip discovery and treat every address as up (like nmap -Pn)
 asphyxia as -s 192.168.1.0/24 --Pn -o jsonl | asphyxia ps --stdin --top-ports 100
+
+# Exclude hosts/CIDRs from a subnet scan (inline and/or from a file)
+asphyxia as -s 192.168.1.0/24 --exclude 192.168.1.0/28 --exclude 192.168.1.100
+asphyxia as -s 10.0.0.0/22 --exclude-file skip.txt
 ```
 
 | Flag | Description |
@@ -158,11 +168,15 @@ asphyxia as -s 192.168.1.0/24 --Pn -o jsonl | asphyxia ps --stdin --top-ports 10
 | `-t, --target <IP>` | Scan a single IPv4 or IPv6 address |
 | `-r, --range <START> <END>` | Scan an inclusive range of IPs (start and end must share the same family) |
 | `--Pn` (`--skip-discovery`) | Skip host discovery and treat every target as up (like nmap `-Pn`) |
+| `--exclude <SPEC>` | Exclude hosts/CIDRs from the scan (repeatable; each value may be comma-separated) |
+| `--exclude-file <PATH>` | Exclude hosts/CIDRs listed in a file (one per line; `#` comments allowed) |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
+
+> `--exclude-cdn` uses a small, static list of well-known CDN/WAF ranges (Cloudflare, Fastly, some Akamai) baked into the binary. It is a convenience, not an authoritative registry, and can drift as providers change allocations.
 
 > Host availability is inferred from TCP probes across a small spread of common ports (80, 443, 22, 3389), tried in order until one answers: a host counts as up when any probed port either accepts the connection or actively refuses it (a closed port still proves the host answered). Probing more than one port finds live hosts that firewall port 80 but answer elsewhere. Only when every probed port times out or is unreachable is the host reported as down — so a host that silently drops packets on all of them may still appear offline. This is an unprivileged, best-effort check, not an ICMP ping; use `--Pn` to skip discovery entirely and treat every target as up.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -45,6 +45,10 @@ Examples:
   # Skip host discovery and treat every address as up (like nmap -Pn)
   asphyxia as -s 192.168.1.0/24 --Pn
 
+  # Exclude hosts/CIDRs, ports, or known CDN/WAF ranges
+  asphyxia as -s 192.168.1.0/24 --exclude 192.168.1.0/28
+  asphyxia ps -t example.com --top-ports 1000 --exclude-ports 9100 --exclude-cdn
+
   # Use a custom connection timeout (milliseconds)
   asphyxia ps -t example.com -s 22,80,443 --timeout 500
 
@@ -119,6 +123,14 @@ pub enum Args {
         #[arg(long = "ports", value_name = "NAME", group = "ports")]
         port_set: Option<String>,
 
+        /// Remove these comma-separated ports from the scan set
+        #[arg(long = "exclude-ports", value_name = "PORTS")]
+        exclude_ports: Option<String>,
+
+        /// For known CDN/WAF targets, scan only 80 and 443 instead of the full set
+        #[arg(long = "exclude-cdn")]
+        exclude_cdn: bool,
+
         /// Connection timeout in milliseconds
         #[arg(long, value_name = "MS", default_value_t = 2000)]
         timeout: u64,
@@ -157,6 +169,14 @@ pub enum Args {
         /// Skip host discovery and treat every target as up (like nmap -Pn)
         #[arg(long = "Pn", visible_alias = "skip-discovery")]
         no_discovery: bool,
+
+        /// Exclude these hosts/CIDRs from the scan (repeatable, comma-separated)
+        #[arg(long = "exclude", value_name = "SPEC")]
+        exclude: Vec<String>,
+
+        /// Exclude hosts/CIDRs listed in a file (one per line)
+        #[arg(long = "exclude-file", value_name = "PATH")]
+        exclude_file: Option<PathBuf>,
 
         /// Connection timeout in milliseconds
         #[arg(long, value_name = "MS", default_value_t = 2000)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,10 @@ pub mod utils;
 
 pub use output::{OutputFormat, ScanRecord, emit, render};
 pub use scanner::address::{
-    HostHit, range_addresses, scan_address, scan_address_with_retries, scan_ip_range,
+    HostHit, range_addresses, scan_address, scan_address_with_retries, scan_hosts, scan_ip_range,
     scan_ip_range_with_retries, scan_subnet, scan_subnet_with_retries, subnet_addresses,
 };
+pub use scanner::exclude::ExcludeSet;
 /// Re-export commonly used types and functions
 pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};
 pub use utils::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::net::IpAddr;
+use std::path::Path;
 use std::time::Duration;
 
 use clap::Parser;
@@ -7,6 +8,7 @@ use rayon::prelude::*;
 
 use asphyxia::cli::Args;
 use asphyxia::output::{OutputFormat, ScanRecord, emit};
+use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
 use asphyxia::scanner::{address, port};
 use asphyxia::utils::{
@@ -23,6 +25,44 @@ fn all_up(addrs: Vec<IpAddr>) -> Vec<address::HostHit> {
             latency: Duration::ZERO,
         })
         .collect()
+}
+
+/// Build the address exclusion set from the `--exclude` specs and an optional
+/// `--exclude-file`. Blank lines and `#` comments in the file are ignored.
+fn build_exclude_set(specs: &[String], file: Option<&Path>) -> Result<ExcludeSet, String> {
+    let mut all: Vec<String> = specs.to_vec();
+    if let Some(path) = file {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| format!("Could not read exclude file {}: {}", path.display(), e))?;
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            all.push(line.to_string());
+        }
+    }
+    ExcludeSet::parse(all)
+}
+
+/// Filter out excluded addresses, then either mark the survivors up (for `-Pn`)
+/// or scan them.
+fn scan_filtered(
+    addrs: Vec<IpAddr>,
+    exclude: &ExcludeSet,
+    no_discovery: bool,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Vec<address::HostHit> {
+    let filtered: Vec<IpAddr> = addrs
+        .into_iter()
+        .filter(|ip| !exclude.contains(*ip))
+        .collect();
+    if no_discovery {
+        all_up(filtered)
+    } else {
+        address::scan_hosts(filtered, timeout, retries)
+    }
 }
 
 fn main() {
@@ -44,12 +84,14 @@ fn main() {
             all_ports,
             top_ports: top_n,
             port_set,
+            exclude_ports,
+            exclude_cdn,
             timeout,
             ..
         } => {
             let timeout = Some(Duration::from_millis(timeout));
 
-            let ports: Vec<u16> = if all_ports {
+            let mut ports: Vec<u16> = if all_ports {
                 (1..=u16::MAX).collect()
             } else if let Some(range) = range {
                 // clap enforces exactly two values via `num_args = 2`.
@@ -91,6 +133,36 @@ fn main() {
                 );
                 return;
             };
+
+            // Drop any explicitly excluded ports from the set.
+            if let Some(spec) = exclude_ports {
+                match parse_ports(&spec) {
+                    Ok(excluded) => {
+                        let excluded: std::collections::HashSet<u16> =
+                            excluded.into_iter().collect();
+                        ports.retain(|p| !excluded.contains(p));
+                    }
+                    Err(e) => {
+                        eprintln!("{}", e.red());
+                        return;
+                    }
+                }
+            }
+
+            if ports.is_empty() {
+                eprintln!("{}", "No ports left to scan after exclusions".yellow());
+                return;
+            }
+
+            // When --exclude-cdn is set, CDN/WAF targets are scanned only on the
+            // web ports rather than the full set (a deep scan there is pointless
+            // and antisocial). Precompute the CDN ranges and the web subset once.
+            let cdn = exclude_cdn.then(ExcludeSet::cdn);
+            let web_ports: Vec<u16> = ports
+                .iter()
+                .copied()
+                .filter(|p| *p == 80 || *p == 443)
+                .collect();
 
             // Gather the raw targets: either the single `-t` host, or a batch
             // read from stdin (clap guarantees exactly one of the two is set).
@@ -142,10 +214,17 @@ fn main() {
 
             // Fan every (host, port) pair out across the shared pool so that
             // multiple hosts are probed concurrently, not one after another.
+            // A CDN/WAF target (with --exclude-cdn) is limited to its web ports.
             let jobs: Vec<(usize, u16)> = resolved
                 .iter()
                 .enumerate()
-                .flat_map(|(i, _)| ports.iter().map(move |&port| (i, port)))
+                .flat_map(|(i, (_, ip))| {
+                    let is_cdn = cdn.as_ref().is_some_and(|c| {
+                        ip.parse::<IpAddr>().map(|a| c.contains(a)).unwrap_or(false)
+                    });
+                    let plist: &[u16] = if is_cdn { &web_ports } else { &ports };
+                    plist.iter().map(move |&port| (i, port))
+                })
                 .collect();
 
             let pb = progress_bar(jobs.len() as u64, "ports scanned");
@@ -212,10 +291,25 @@ fn main() {
             target,
             range,
             no_discovery,
+            exclude,
+            exclude_file,
             timeout,
             ..
         } => {
             let timeout = Some(Duration::from_millis(timeout));
+
+            let exclude_set = match build_exclude_set(&exclude, exclude_file.as_deref()) {
+                Ok(set) => set,
+                Err(e) => {
+                    eprintln!("{}", e.red());
+                    return;
+                }
+            };
+
+            // Enumerate-filter-scan only when it earns its keep (exclusions or
+            // -Pn); otherwise keep the lazy subnet/range scan that never
+            // materialises the whole address space.
+            let materialize = no_discovery || !exclude_set.is_empty();
 
             let available: Vec<address::HostHit> = if let Some(subnet_str) = subnet {
                 match parse_subnet(&subnet_str) {
@@ -227,8 +321,14 @@ fn main() {
                                 subnet_str.as_str().bright_green()
                             );
                         }
-                        if no_discovery {
-                            all_up(address::subnet_addresses(network))
+                        if materialize {
+                            scan_filtered(
+                                address::subnet_addresses(network),
+                                &exclude_set,
+                                no_discovery,
+                                timeout,
+                                retries,
+                            )
                         } else {
                             address::scan_subnet_with_retries(network, timeout, retries)
                         }
@@ -248,8 +348,8 @@ fn main() {
                                 target_str.as_str().bright_green()
                             );
                         }
-                        if no_discovery {
-                            all_up(vec![ip])
+                        if materialize {
+                            scan_filtered(vec![ip], &exclude_set, no_discovery, timeout, retries)
                         } else {
                             address::scan_address_with_retries(ip, timeout, retries)
                                 .into_iter()
@@ -273,8 +373,14 @@ fn main() {
                                 range_vec[1].as_str().bright_green()
                             );
                         }
-                        if no_discovery {
-                            all_up(address::range_addresses(start, end))
+                        if materialize {
+                            scan_filtered(
+                                address::range_addresses(start, end),
+                                &exclude_set,
+                                no_discovery,
+                                timeout,
+                                retries,
+                            )
                         } else {
                             address::scan_ip_range_with_retries(start, end, timeout, retries)
                         }

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -145,6 +145,24 @@ fn probe_port(ip: IpAddr, port: u16, timeout: Duration) -> Option<HostHit> {
     }
 }
 
+/// Scan an explicit list of addresses in parallel and return the ones that are
+/// available, sorted ascending.
+///
+/// This is the entry point used when the caller has already materialised and
+/// filtered the address list (for example after applying `--exclude`), rather
+/// than enumerating a whole subnet or range. Each probe is retried up to
+/// `retries` extra times on silence (see [`scan_address_with_retries`]).
+pub fn scan_hosts(addrs: Vec<IpAddr>, timeout: Option<Duration>, retries: u32) -> Vec<HostHit> {
+    let total = addrs.len() as u64;
+    scan_all(
+        addrs.into_par_iter(),
+        total,
+        timeout,
+        retries,
+        "Scan completed",
+    )
+}
+
 /// Scan every address yielded by `addrs` in parallel and return the ones that
 /// are available, sorted ascending.
 ///

--- a/src/scanner/exclude.rs
+++ b/src/scanner/exclude.rs
@@ -1,0 +1,160 @@
+//! Address exclusions for scans.
+//!
+//! An [`ExcludeSet`] is a collection of individual IPs and CIDR blocks that a
+//! scan should skip. It backs `--exclude`/`--exclude-file` (user-supplied
+//! addresses to leave alone) and `--exclude-cdn` (a built-in set of CDN/WAF
+//! ranges where an exhaustive port scan is pointless and antisocial).
+
+use std::net::IpAddr;
+
+use ipnetwork::IpNetwork;
+
+/// A set of addresses to skip, expressed as CIDR blocks.
+///
+/// A bare IP is stored as a host route (`/32` or `/128`), so membership is a
+/// single containment test against every block.
+#[derive(Debug, Clone, Default)]
+pub struct ExcludeSet {
+    nets: Vec<IpNetwork>,
+}
+
+impl ExcludeSet {
+    /// Parse exclusion specs into a set. Each spec may itself be a
+    /// comma-separated list, and every token is either a CIDR (`10.0.0.0/8`) or
+    /// a bare IP (`192.168.1.5`, treated as a host route).
+    ///
+    /// Returns an error naming the first token that does not parse.
+    pub fn parse<I, S>(specs: I) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut nets = Vec::new();
+        for spec in specs {
+            for token in spec.as_ref().split(',') {
+                let token = token.trim();
+                if token.is_empty() {
+                    continue;
+                }
+                nets.push(parse_net(token)?);
+            }
+        }
+        Ok(Self { nets })
+    }
+
+    /// The built-in set of well-known CDN/WAF ranges (Cloudflare, Akamai, …).
+    ///
+    /// This list is baked in and static: it is a convenience, not an
+    /// authoritative registry, and can drift as providers change allocations.
+    pub fn cdn() -> Self {
+        let nets = CDN_RANGES
+            .iter()
+            // The built-in ranges are known-valid CIDRs.
+            .map(|c| c.parse::<IpNetwork>().expect("valid built-in CDN CIDR"))
+            .collect();
+        Self { nets }
+    }
+
+    /// Whether the set contains no exclusions.
+    pub fn is_empty(&self) -> bool {
+        self.nets.is_empty()
+    }
+
+    /// Whether `ip` falls inside any excluded block.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        self.nets.iter().any(|net| net.contains(ip))
+    }
+}
+
+/// Parse one token as a CIDR, or as a bare IP promoted to a host route.
+fn parse_net(token: &str) -> Result<IpNetwork, String> {
+    if token.contains('/') {
+        return token
+            .parse::<IpNetwork>()
+            .map_err(|_| format!("Invalid exclude CIDR: {}", token));
+    }
+    let ip = token
+        .parse::<IpAddr>()
+        .map_err(|_| format!("Invalid exclude address: {}", token))?;
+    let prefix = match ip {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    // A host route with the full prefix cannot be rejected for a parsed IP.
+    IpNetwork::new(ip, prefix).map_err(|_| format!("Invalid exclude address: {}", token))
+}
+
+/// Well-known CDN/WAF IPv4 ranges. Static and best-effort — see [`ExcludeSet::cdn`].
+static CDN_RANGES: &[&str] = &[
+    // Cloudflare (https://www.cloudflare.com/ips/)
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+    // Fastly
+    "151.101.0.0/16",
+    // A couple of Akamai blocks (non-exhaustive)
+    "23.32.0.0/11",
+    "104.64.0.0/10",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mixed_ips_and_cidrs_across_and_within_args() {
+        let set = ExcludeSet::parse(["192.168.1.5", "10.0.0.0/8,172.16.0.0/12"]).unwrap();
+        assert!(set.contains("192.168.1.5".parse().unwrap()));
+        assert!(!set.contains("192.168.1.6".parse().unwrap()));
+        assert!(set.contains("10.1.2.3".parse().unwrap()));
+        assert!(set.contains("172.16.5.5".parse().unwrap()));
+        assert!(!set.contains("11.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn empty_specs_yield_an_empty_set() {
+        let set = ExcludeSet::parse(Vec::<String>::new()).unwrap();
+        assert!(set.is_empty());
+        assert!(!set.contains("1.2.3.4".parse().unwrap()));
+    }
+
+    #[test]
+    fn blank_tokens_are_skipped() {
+        let set = ExcludeSet::parse([" , ,10.0.0.0/8, "]).unwrap();
+        assert!(set.contains("10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rejects_garbage_tokens() {
+        assert!(ExcludeSet::parse(["not-an-ip"]).is_err());
+        assert!(ExcludeSet::parse(["10.0.0.0/99"]).is_err());
+    }
+
+    #[test]
+    fn ipv6_host_route_matches_only_itself() {
+        let set = ExcludeSet::parse(["2001:db8::1"]).unwrap();
+        assert!(set.contains("2001:db8::1".parse().unwrap()));
+        assert!(!set.contains("2001:db8::2".parse().unwrap()));
+    }
+
+    #[test]
+    fn cdn_set_flags_cloudflare_ranges() {
+        let cdn = ExcludeSet::cdn();
+        // 104.16.0.1 is inside Cloudflare's 104.16.0.0/13.
+        assert!(cdn.contains("104.16.0.1".parse().unwrap()));
+        // A random private address is not a CDN.
+        assert!(!cdn.contains("192.168.0.1".parse().unwrap()));
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -6,7 +6,9 @@
 //! * `port` - Port scanning functionality
 //! * `address` - Address scanning functionality
 //! * `well_known` - Frequency-ordered top ports and named port sets
+//! * `exclude` - Address and CDN exclusions for scans
 
 pub mod address;
+pub mod exclude;
 pub mod port;
 pub mod well_known;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -267,6 +267,91 @@ fn port_scan_grep_with_no_open_ports_emits_nothing() {
 }
 
 #[test]
+fn exclude_ports_removing_the_only_port_prints_guidance() {
+    // The only requested port is also excluded, so nothing is left to scan.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "--exclude-ports", "1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("No ports left to scan"));
+}
+
+#[test]
+fn exclude_ports_rejects_invalid_list() {
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1,2",
+            "--exclude-ports",
+            "nope",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Invalid port number: nope"));
+}
+
+#[test]
+fn address_scan_exclude_rejects_invalid_spec() {
+    asphyxia()
+        .args(["as", "-s", "10.0.0.0/30", "--exclude", "not-an-ip"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Invalid exclude address"));
+}
+
+#[test]
+fn address_scan_exclude_filters_hosts_from_a_pn_scan() {
+    // -Pn marks every address up without probing; --exclude removes one of them,
+    // so the excluded address must not appear in the output.
+    asphyxia()
+        .args([
+            "as",
+            "-r",
+            "10.20.30.1",
+            "10.20.30.4",
+            "--Pn",
+            "--exclude",
+            "10.20.30.2",
+            "-o",
+            "grep",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("10.20.30.1"))
+        .stdout(predicate::str::contains("10.20.30.4"))
+        .stdout(predicate::str::contains("10.20.30.2").not());
+}
+
+#[test]
+fn address_scan_exclude_file_is_read() {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-exclude-{}.txt", std::process::id()));
+    std::fs::write(&path, "# comment\n10.20.31.3\n\n").unwrap();
+
+    asphyxia()
+        .args([
+            "as",
+            "-r",
+            "10.20.31.1",
+            "10.20.31.4",
+            "--Pn",
+            "--exclude-file",
+            path.to_str().unwrap(),
+            "-o",
+            "grep",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("10.20.31.3").not())
+        .stdout(predicate::str::contains("10.20.31.1"));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn output_file_writes_machine_output_and_keeps_stdout_clean() {
     let dir = std::env::temp_dir();
     let path = dir.join(format!("asphyxia-cli-out-{}.csv", std::process::id()));


### PR DESCRIPTION
## What

Closes #17.

Adds three ways to keep targets out of a scan:

- `--exclude <SPEC>` / `--exclude-file <PATH>` (on `as`) — skip these hosts/CIDRs in a subnet or range scan. `--exclude` is repeatable and each value may be comma-separated; the file allows one entry per line with blank lines and `#` comments.
- `--exclude-ports <LIST>` (on `ps`) — subtract ports from the final set.
- `--exclude-cdn` (on `ps`) — for targets inside a built-in set of well-known CDN/WAF ranges (Cloudflare, Fastly, some Akamai), scan only 80/443 instead of the full set, where a deep scan is pointless and antisocial.

## Implementation

- New `src/scanner/exclude.rs`: `ExcludeSet` (a list of CIDR blocks; bare IPs become host routes) with `parse`, `contains`, and a built-in `cdn()` set. Fully offline.
- `src/scanner/address.rs`: `scan_hosts` scans an explicit, already-filtered address list.
- `src/main.rs`: port exclusions subtracted before fan-out; CDN targets limited to their web ports in the job list; address scans enumerate-filter-scan only when exclusions or `-Pn` are in play, keeping the lazy path for unbounded scans.

## Tests

- Unit: mixed IP/CIDR parsing across and within args, blank-token skipping, garbage rejection, IPv6 host route, CDN detection.
- CLI: excluding the only port prints guidance, invalid port/spec errors, `--exclude` filters a host from a `-Pn` scan, and `--exclude-file` (with comment/blank lines) is honored.

## Docs

README (`ps`/`as` examples, flag tables, CDN caveat) and CLI `--help` updated.

> Note: the CDN list is static and best-effort — documented as such in the README and code.