### PR TITLE
Add nmap handoff (--nmap): pipe open ports into nmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ asphyxia ps -t example.com --ports web
 asphyxia ps -t example.com --top-ports 1000 --exclude-ports 9100,631
 asphyxia ps --stdin --top-ports 1000 --exclude-cdn < hosts.txt
 
+# Find open ports fast, then hand them to nmap for a deep dive
+asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
+asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
+
 # Scan an IPv6 host with a shorter timeout
 asphyxia ps -t 2001:db8::1 -s 22,80,443 --timeout 500
 
@@ -131,6 +135,8 @@ Exactly one target source is required — either `-t/--host` or `--stdin` — an
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--exclude-ports <PORTS>` | Remove these comma-separated ports from the scan set |
 | `--exclude-cdn` | For known CDN/WAF targets, scan only 80 and 443 instead of the full set |
+| `--nmap` | After the scan, run nmap on each host's open ports for a deep dive |
+| `--nmap-args <ARGS>` | Custom nmap arguments (replace the default `-sV -sC`); implies `--nmap` |
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
@@ -227,6 +233,20 @@ asphyxia as -s 192.168.1.0/24 -o jsonl 2>/dev/null \
 # Feed a hand-written host list
 asphyxia ps --stdin -s 22,80,443 < hosts.txt
 ```
+
+### Nmap handoff (`--nmap`)
+
+Asphyxia finds open ports quickly; nmap interrogates them thoroughly. `--nmap` bridges the two: after the scan, it groups the open ports by host and runs `nmap` on each, so the classic "scan fast, then deep-dive" workflow is one command.
+
+```bash
+# Fast port sweep, then nmap service/version + default scripts on what's open
+asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
+
+# Pass your own nmap flags (these replace the default -sV -sC); ports/target stay owned by asphyxia
+asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
+```
+
+By default asphyxia runs `nmap -sV -sC -p <open-ports> <host>`. With `--nmap-args` your flags replace `-sV -sC`, while asphyxia still supplies `-p <open-ports>` and the target. If nmap is not on your `PATH`, asphyxia prints an install hint instead of a deep dive. Nmap's output streams straight to the terminal, so combine `--nmap` with the human (`text`) output rather than a machine format.
 
 ## Performance
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,10 @@ Examples:
   asphyxia ps -t example.com --top-ports 100
   asphyxia ps -t example.com --ports web
 
+  # Find open ports fast, then hand them to nmap for a deep dive
+  asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
+  asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
+
   # Feed live hosts from an address scan straight into a port scan
   asphyxia as -s 192.168.1.0/24 -o jsonl | asphyxia ps --stdin -s 22,80,443
   asphyxia as -s 192.168.1.0/24 -o jsonl | asphyxia ps --stdin --all-ports
@@ -130,6 +134,19 @@ pub enum Args {
         /// For known CDN/WAF targets, scan only 80 and 443 instead of the full set
         #[arg(long = "exclude-cdn")]
         exclude_cdn: bool,
+
+        /// After the scan, run nmap on each host's open ports for a deep dive
+        #[arg(long = "nmap")]
+        nmap: bool,
+
+        /// Custom nmap arguments (replace the default -sV -sC); implies --nmap
+        #[arg(
+            long = "nmap-args",
+            value_name = "ARGS",
+            requires = "nmap",
+            allow_hyphen_values = true
+        )]
+        nmap_args: Option<String>,
 
         /// Connection timeout in milliseconds
         #[arg(long, value_name = "MS", default_value_t = 2000)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub use scanner::address::{
     scan_ip_range_with_retries, scan_subnet, scan_subnet_with_retries, subnet_addresses,
 };
 pub use scanner::exclude::ExcludeSet;
+pub use scanner::nmap::{nmap_args, run_nmap, split_extra_args};
 /// Re-export commonly used types and functions
 pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};
 pub use utils::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use asphyxia::cli::Args;
 use asphyxia::output::{OutputFormat, ScanRecord, emit};
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
-use asphyxia::scanner::{address, port};
+use asphyxia::scanner::{address, nmap, port};
 use asphyxia::utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_stdin,
 };
@@ -43,6 +43,53 @@ fn build_exclude_set(specs: &[String], file: Option<&Path>) -> Result<ExcludeSet
         }
     }
     ExcludeSet::parse(all)
+}
+
+/// Hand each scanned host's open ports off to nmap, grouping the flat
+/// `(host_index, hit)` list by host. Nothing runs for hosts with no open ports.
+///
+/// A missing nmap binary is reported once with an install hint rather than
+/// failing per host; any other spawn error is surfaced per host.
+fn run_nmap_handoff(
+    resolved: &[(String, String)],
+    opened: &[(usize, port::PortHit)],
+    extra: &[String],
+) {
+    use std::io::ErrorKind;
+
+    // `opened` is already sorted by (host index, port), so consecutive runs of
+    // the same index group a host's ports together.
+    let mut idx = 0;
+    while idx < opened.len() {
+        let host_i = opened[idx].0;
+        let mut ports = Vec::new();
+        while idx < opened.len() && opened[idx].0 == host_i {
+            ports.push(opened[idx].1.port);
+            idx += 1;
+        }
+
+        let host = &resolved[host_i].0;
+        println!(
+            "\n##### {} nmap on {} #####\n",
+            "Handing off to".bright_blue(),
+            host.bright_green()
+        );
+        match nmap::run_nmap(host, &ports, extra) {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                eprintln!(
+                    "{}",
+                    "nmap not found on PATH — install nmap (https://nmap.org/download) to use --nmap"
+                        .red()
+                );
+                // No point retrying the remaining hosts if nmap is absent.
+                return;
+            }
+            Err(e) => {
+                eprintln!("{}", format!("Failed to run nmap on {}: {}", host, e).red());
+            }
+        }
+    }
 }
 
 /// Filter out excluded addresses, then either mark the survivors up (for `-Pn`)
@@ -86,6 +133,8 @@ fn main() {
             port_set,
             exclude_ports,
             exclude_cdn,
+            nmap,
+            nmap_args,
             timeout,
             ..
         } => {
@@ -284,6 +333,12 @@ fn main() {
                         eprintln!("{}", format!("Failed to write output: {}", e).red());
                     }
                 }
+            }
+
+            // Optional deep-dive: hand each host's open ports to nmap.
+            if nmap {
+                let extra = nmap_args.as_deref().map(nmap::split_extra_args);
+                run_nmap_handoff(&resolved, &opened, extra.as_deref().unwrap_or(&[]));
             }
         }
         Args::AddressScan {

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -7,8 +7,10 @@
 //! * `address` - Address scanning functionality
 //! * `well_known` - Frequency-ordered top ports and named port sets
 //! * `exclude` - Address and CDN exclusions for scans
+//! * `nmap` - Handoff of discovered open ports to nmap
 
 pub mod address;
 pub mod exclude;
+pub mod nmap;
 pub mod port;
 pub mod well_known;

--- a/src/scanner/nmap.rs
+++ b/src/scanner/nmap.rs
@@ -1,0 +1,101 @@
+//! Nmap handoff: hand a host's open ports to `nmap` for a deeper look.
+//!
+//! Asphyxia's job is to find open ports fast; nmap's is to interrogate them
+//! (service/version detection, default scripts). This module builds the nmap
+//! invocation for a host and its discovered ports and runs it, so the common
+//! "scan fast, then deep-dive" workflow is a single command.
+
+use std::io;
+use std::process::{Command, ExitStatus};
+
+/// Default nmap scan flags used when the user does not supply their own via
+/// `--nmap-args`: service/version detection plus the default script set.
+pub const DEFAULT_NMAP_ARGS: &[&str] = &["-sV", "-sC"];
+
+/// Build the full nmap argument vector for `host` and its open `ports`.
+///
+/// When `extra` is non-empty it replaces the [`DEFAULT_NMAP_ARGS`] scan flags;
+/// either way asphyxia always appends `-p <ports>` and the target host, since it
+/// owns which ports to hand off. Ports are emitted in the given order as a
+/// comma-separated list.
+pub fn nmap_args(host: &str, ports: &[u16], extra: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = if extra.is_empty() {
+        DEFAULT_NMAP_ARGS.iter().map(|s| s.to_string()).collect()
+    } else {
+        extra.to_vec()
+    };
+
+    let port_list = ports
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    args.push("-p".to_string());
+    args.push(port_list);
+    args.push(host.to_string());
+    args
+}
+
+/// Split a raw `--nmap-args` string into individual arguments on whitespace.
+///
+/// This is a simple split, not a full shell parser: it does not honour quotes.
+/// Empty input yields no arguments (the defaults then apply).
+pub fn split_extra_args(raw: &str) -> Vec<String> {
+    raw.split_whitespace().map(|s| s.to_string()).collect()
+}
+
+/// Run `nmap` against `host` for the given open `ports`, inheriting stdio so its
+/// report streams straight to the terminal.
+///
+/// Returns the process exit status, or an [`io::Error`] if nmap could not be
+/// started — notably [`io::ErrorKind::NotFound`] when nmap is not on `PATH`.
+pub fn run_nmap(host: &str, ports: &[u16], extra: &[String]) -> io::Result<ExitStatus> {
+    Command::new("nmap")
+        .args(nmap_args(host, ports, extra))
+        .status()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_used_when_no_extra_args() {
+        let args = nmap_args("scanme.nmap.org", &[22, 80], &[]);
+        assert_eq!(
+            args,
+            vec!["-sV", "-sC", "-p", "22,80", "scanme.nmap.org"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn extra_args_replace_defaults_but_ports_and_host_are_appended() {
+        let extra = split_extra_args("-A -T4");
+        let args = nmap_args("10.0.0.1", &[443], &extra);
+        assert_eq!(
+            args,
+            vec!["-A", "-T4", "-p", "443", "10.0.0.1"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ports_are_joined_in_order() {
+        let args = nmap_args("host", &[80, 22, 8080], &[]);
+        // The port list is the entry right after "-p".
+        let idx = args.iter().position(|a| a == "-p").unwrap();
+        assert_eq!(args[idx + 1], "80,22,8080");
+    }
+
+    #[test]
+    fn split_extra_args_handles_blank_and_whitespace() {
+        assert!(split_extra_args("").is_empty());
+        assert!(split_extra_args("   ").is_empty());
+        assert_eq!(split_extra_args("  -sS   -Pn "), vec!["-sS", "-Pn"]);
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -267,6 +267,27 @@ fn port_scan_grep_with_no_open_ports_emits_nothing() {
 }
 
 #[test]
+fn nmap_args_requires_the_nmap_flag() {
+    // --nmap-args without --nmap is a parse error (clap `requires`).
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "80", "--nmap-args", "-A"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("nmap"));
+}
+
+#[test]
+fn nmap_flag_with_no_open_ports_does_not_invoke_nmap() {
+    // Port 1 on loopback is closed, so there is no handoff and the run succeeds
+    // regardless of whether nmap is installed on the CI machine.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "--nmap"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No open ports found"));
+}
+
+#[test]
 fn exclude_ports_removing_the_only_port_prints_guidance() {
     // The only requested port is also excluded, so nothing is left to scan.
     asphyxia()


### PR DESCRIPTION
## What

Closes #13.

Bridges asphyxia's fast port discovery and nmap's deep inspection. After the port scan, `--nmap` groups the open ports by host and runs nmap on each:

- Default invocation: `nmap -sV -sC -p <open-ports> <host>`.
- `--nmap-args "<...>"` replaces the default scan flags (`-sV -sC`) while asphyxia still supplies `-p <open-ports>` and the target. Implies `--nmap`.
- If nmap is not on `PATH`, a clear install hint is printed instead of crashing; other spawn errors are reported per host.

## Implementation

- New `src/scanner/nmap.rs`: `nmap_args` (pure, testable arg builder), `split_extra_args`, and `run_nmap` (inherits stdio so nmap streams to the terminal).
- `src/main.rs`: `run_nmap_handoff` walks the already-sorted `(host, port)` results, groups per host, and invokes nmap; nothing runs for hosts with no open ports.
- `src/cli/mod.rs`: `--nmap` / `--nmap-args` (with `allow_hyphen_values` so flags like `-A` are accepted as the value, and `requires = "nmap"`).

## Tests

- Unit: default flags used with no extras, extras replace defaults but ports/host are appended, ports joined in order, whitespace/blank arg splitting.
- CLI: `--nmap-args` without `--nmap` is rejected; `--nmap` with no open ports does not invoke nmap (deterministic on CI without nmap installed).

## Docs

README (`ps` examples, flag table, dedicated handoff section) and CLI `--help` updated.