### PR TITLE
Add target file input (-iL) and config profiles (~/.asphyxia.toml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -223,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,10 +239,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indicatif"
@@ -480,6 +503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +533,47 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -668,3 +741,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ owo-colors = "4.2.1"
 ipnetwork = "0.20.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 - **Colorized output** — readable, colored terminal output.
 - **Machine-readable output** — emit results as JSON, JSON Lines, CSV, or greppable text with `--output`, and write them straight to a file with `--output-file`, for piping into other tools.
 
+- **Target sources** — scan a single host, pipe targets in with `--stdin`, or read them from a file with `-i/--target-file`; hosts, IPs, and CIDRs are all accepted, and CIDRs in a file are expanded.
+- **Configuration file** — set defaults (timeout, concurrency, retries, output format) in `~/.asphyxia.toml`; command-line flags override it.
+
 > Note: IPv6 subnet and range scans are capped at 65 536 addresses (e.g. a `/112`), since larger IPv6 spaces are impractical to walk exhaustively.
 
 ## Installation
@@ -120,14 +123,18 @@ asphyxia ps -t 2001:db8::1 -s 22,80,443 --timeout 500
 
 # Read targets from stdin instead of -t (one host per line, or JSON/JSONL from `as`)
 asphyxia ps --stdin -s 22,80,443 < hosts.txt
+
+# Read targets from a file (hosts, IPs, or CIDRs; CIDRs are expanded)
+asphyxia ps -i targets.txt --top-ports 100
 ```
 
-Exactly one target source is required — either `-t/--host` or `--stdin` — and they are mutually exclusive. Likewise `-r`, `-s`, `--all-ports`, `--top-ports`, and `--ports` are mutually exclusive.
+Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--target-file` — and they are mutually exclusive. Likewise `-r`, `-s`, `--all-ports`, `--top-ports`, and `--ports` are mutually exclusive.
 
 | Flag | Description |
 |------|-------------|
 | `-t, --host <HOST>` | Target host (hostname, IPv4, or IPv6) |
 | `--stdin` | Read targets from stdin instead of `-t`: one host per line, or the JSON/JSONL emitted by `asphyxia as -o` (the `ip` field is used) |
+| `-i, --target-file <PATH>` (`--iL`) | Read targets from a file: hosts, IPs, CIDRs (expanded), or `as` JSON/JSONL, one per line |
 | `-r, --range <START> <END>` | Scan an inclusive range of ports |
 | `-s, --specific <PORTS>` | Scan specific comma-separated ports |
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
@@ -247,6 +254,20 @@ asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
 ```
 
 By default asphyxia runs `nmap -sV -sC -p <open-ports> <host>`. With `--nmap-args` your flags replace `-sV -sC`, while asphyxia still supplies `-p <open-ports>` and the target. If nmap is not on your `PATH`, asphyxia prints an install hint instead of a deep dive. Nmap's output streams straight to the terminal, so combine `--nmap` with the human (`text`) output rather than a machine format.
+
+## Configuration file (`~/.asphyxia.toml`)
+
+For repeated runs you can set defaults in `~/.asphyxia.toml` instead of retyping the same flags. Every key is optional; anything you omit keeps its built-in default. Command-line flags always override the config.
+
+```toml
+# ~/.asphyxia.toml
+timeout     = 500     # per-connection timeout in ms
+concurrency = 512     # max concurrent connection attempts
+retries     = 1       # extra retries per probe on no answer
+output      = "jsonl" # default output format: text | json | jsonl | csv | grep
+```
+
+With that config, `asphyxia ps -t example.com --top-ports 100` runs with a 500 ms timeout, 512-way concurrency, one retry, and JSONL output — while `asphyxia ps -t example.com --top-ports 100 -o text --timeout 2000` overrides both the format and the timeout for that run. Point `ASPHYXIA_CONFIG` at a different path to use an alternate file. An invalid config is reported on stderr and then ignored rather than aborting the scan.
 
 ## Performance
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,9 @@ Examples:
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
 
+  # Read targets from a file (hosts, IPs, or CIDRs; one per line)
+  asphyxia ps -i targets.txt --top-ports 100
+
   # Feed live hosts from an address scan straight into a port scan
   asphyxia as -s 192.168.1.0/24 -o jsonl | asphyxia ps --stdin -s 22,80,443
   asphyxia as -s 192.168.1.0/24 -o jsonl | asphyxia ps --stdin --all-ports
@@ -74,6 +77,7 @@ Required arguments:
     -t, --host <HOST>    Target host to scan (e.g., example.com)
     --stdin              Read targets from stdin instead of -t (one host per line, or
                          JSON/JSONL from `asphyxia as -o`); mutually exclusive with -t
+    -i, --target-file <PATH>     Read targets from a file (hosts, IPs, or CIDRs, one per line)
     -r, --range <START> <END>    Scan a range of ports (e.g., 80 443)
     -s, --specific <PORTS>       Scan specific ports (comma-separated, e.g., 22,80,443)
     -a, --all-ports              Scan the entire port range (1-65535)
@@ -94,8 +98,8 @@ pub enum Args {
     #[command(
         name = "ps",
         about = "Start port scanning",
-        // Exactly one target source is required: a `-t` host or `--stdin`.
-        group = ArgGroup::new("target").required(true).args(["host", "stdin"])
+        // Exactly one target source is required: `-t`, `--stdin`, or `-iL`.
+        group = ArgGroup::new("target").required(true).args(["host", "stdin", "target_file"])
     )]
     PortScan {
         /// Target host (e.g., example.com)
@@ -106,6 +110,16 @@ pub enum Args {
         /// JSON/JSONL emitted by `asphyxia as -o` (the `ip` field is used).
         #[arg(long, group = "target")]
         stdin: bool,
+
+        /// Read targets from a file (hosts, IPs, or CIDRs; one per line)
+        #[arg(
+            short = 'i',
+            long = "target-file",
+            visible_alias = "iL",
+            value_name = "PATH",
+            group = "target"
+        )]
+        target_file: Option<PathBuf>,
 
         /// Scan range of ports: start end
         #[arg(short = 'r', long, num_args = 2, group = "ports")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,116 @@
+//! Configuration profiles loaded from `~/.asphyxia.toml`.
+//!
+//! A config file supplies defaults for repeated runs (timeout, concurrency,
+//! retries, output format) so common options need not be retyped every time.
+//! Every field is optional; a missing field simply falls back to the built-in
+//! default. Command-line flags always win over the config — the merge that
+//! enforces that precedence lives in `main`, which knows which flags the user
+//! actually passed.
+
+use clap::ValueEnum;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::output::OutputFormat;
+
+/// Environment variable that overrides the config file location (mainly for
+/// tests and non-standard setups).
+pub const CONFIG_ENV: &str = "ASPHYXIA_CONFIG";
+
+/// Optional defaults read from `~/.asphyxia.toml`.
+///
+/// Unknown keys are rejected so a typo surfaces as an error rather than being
+/// silently ignored.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Per-connection timeout in milliseconds.
+    pub timeout: Option<u64>,
+    /// Maximum number of concurrent connection attempts.
+    pub concurrency: Option<usize>,
+    /// Extra retries per probe on no answer.
+    pub retries: Option<u32>,
+    /// Output format name (`text`, `json`, `jsonl`, `csv`, `grep`).
+    pub output: Option<String>,
+}
+
+impl Config {
+    /// Parse a config from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Config, String> {
+        toml::from_str(s).map_err(|e| e.to_string())
+    }
+
+    /// Load the config from [`config_path`], returning an empty config when the
+    /// file is absent or unreadable. An existing-but-invalid file is reported
+    /// on stderr and then ignored, so a broken config never aborts a scan.
+    pub fn load() -> Config {
+        let Some(path) = config_path() else {
+            return Config::default();
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return Config::default();
+        };
+        Self::from_toml_str(&text).unwrap_or_else(|e| {
+            eprintln!("warning: ignoring invalid config {}: {}", path.display(), e);
+            Config::default()
+        })
+    }
+
+    /// The configured output format, if set and valid.
+    pub fn output_format(&self) -> Option<OutputFormat> {
+        self.output
+            .as_deref()
+            .and_then(|s| OutputFormat::from_str(s, true).ok())
+    }
+}
+
+/// The path the config is loaded from: `$ASPHYXIA_CONFIG` if set, else
+/// `$HOME/.asphyxia.toml`. Returns `None` when neither is available.
+pub fn config_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(CONFIG_ENV) {
+        return Some(PathBuf::from(path));
+    }
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".asphyxia.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_full_config() {
+        let cfg = Config::from_toml_str(
+            "timeout = 500\nconcurrency = 128\nretries = 2\noutput = \"json\"\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.timeout, Some(500));
+        assert_eq!(cfg.concurrency, Some(128));
+        assert_eq!(cfg.retries, Some(2));
+        assert_eq!(cfg.output_format(), Some(OutputFormat::Json));
+    }
+
+    #[test]
+    fn empty_config_is_all_none() {
+        let cfg = Config::from_toml_str("").unwrap();
+        assert_eq!(cfg, Config::default());
+        assert_eq!(cfg.output_format(), None);
+    }
+
+    #[test]
+    fn partial_config_leaves_the_rest_unset() {
+        let cfg = Config::from_toml_str("timeout = 1000\n").unwrap();
+        assert_eq!(cfg.timeout, Some(1000));
+        assert_eq!(cfg.concurrency, None);
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected() {
+        assert!(Config::from_toml_str("bogus = 1\n").is_err());
+    }
+
+    #[test]
+    fn invalid_output_name_yields_none() {
+        let cfg = Config::from_toml_str("output = \"nonsense\"\n").unwrap();
+        assert_eq!(cfg.output_format(), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,10 +91,12 @@
 //! scanning functions which are optimized for scanning multiple hosts.
 
 pub mod cli;
+pub mod config;
 pub mod output;
 pub mod scanner;
 pub mod utils;
 
+pub use config::Config;
 pub use output::{OutputFormat, ScanRecord, emit, render};
 pub use scanner::address::{
     HostHit, range_addresses, scan_address, scan_address_with_retries, scan_hosts, scan_ip_range,
@@ -105,5 +107,6 @@ pub use scanner::nmap::{nmap_args, run_nmap, split_extra_args};
 /// Re-export commonly used types and functions
 pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};
 pub use utils::{
-    init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_stdin,
+    init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets,
+    read_targets_from_file, read_targets_from_stdin,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,20 @@ use std::net::IpAddr;
 use std::path::Path;
 use std::time::Duration;
 
-use clap::Parser;
+use clap::parser::ValueSource;
+use clap::{ArgMatches, CommandFactory, FromArgMatches};
 use owo_colors::OwoColorize;
 use rayon::prelude::*;
 
 use asphyxia::cli::Args;
+use asphyxia::config::Config;
 use asphyxia::output::{OutputFormat, ScanRecord, emit};
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
 use asphyxia::scanner::{address, nmap, port};
 use asphyxia::utils::{
-    init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_stdin,
+    init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_file,
+    read_targets_from_stdin,
 };
 
 /// Mark every address as up without probing, for `-Pn` (skip discovery). The
@@ -112,8 +115,61 @@ fn scan_filtered(
     }
 }
 
+/// Apply `~/.asphyxia.toml` defaults to `args`, but only for options the user
+/// did not pass on the command line — so CLI flags always win over the config.
+///
+/// The user's intent is read from clap's value source: an option whose value
+/// came from a `default_value` (not the command line) is eligible to be
+/// overridden by the config.
+fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
+    let Some((_, sub)) = matches.subcommand() else {
+        return;
+    };
+    let from_cli = |id: &str| matches!(sub.value_source(id), Some(ValueSource::CommandLine));
+
+    match args {
+        Args::PortScan {
+            timeout,
+            concurrency,
+            retries,
+            output,
+            ..
+        }
+        | Args::AddressScan {
+            timeout,
+            concurrency,
+            retries,
+            output,
+            ..
+        } => {
+            if !from_cli("timeout")
+                && let Some(v) = config.timeout
+            {
+                *timeout = v;
+            }
+            if !from_cli("concurrency")
+                && let Some(v) = config.concurrency
+            {
+                *concurrency = v;
+            }
+            if !from_cli("retries")
+                && let Some(v) = config.retries
+            {
+                *retries = v;
+            }
+            if !from_cli("output")
+                && let Some(v) = config.output_format()
+            {
+                *output = v;
+            }
+        }
+    }
+}
+
 fn main() {
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    let mut args = Args::from_arg_matches(&matches).expect("clap builds valid Args");
+    apply_config(&mut args, &matches, &Config::load());
 
     // Size the global rayon pool for I/O-bound scanning before any scan runs.
     init_scan_pool(args.concurrency());
@@ -126,6 +182,7 @@ fn main() {
         Args::PortScan {
             host,
             stdin,
+            target_file,
             range,
             specific,
             all_ports,
@@ -213,8 +270,9 @@ fn main() {
                 .filter(|p| *p == 80 || *p == 443)
                 .collect();
 
-            // Gather the raw targets: either the single `-t` host, or a batch
-            // read from stdin (clap guarantees exactly one of the two is set).
+            // Gather the raw targets from exactly one source: a single `-t`
+            // host, a batch from stdin, or a batch from a `-iL` file (clap's
+            // required `target` group guarantees precisely one is set).
             let targets: Vec<String> = if stdin {
                 let targets = read_targets_from_stdin();
                 if targets.is_empty() {
@@ -222,9 +280,27 @@ fn main() {
                     return;
                 }
                 targets
+            } else if let Some(path) = target_file {
+                match read_targets_from_file(&path) {
+                    Ok(targets) if targets.is_empty() => {
+                        eprintln!(
+                            "{}",
+                            format!("No targets read from file: {}", path.display()).yellow()
+                        );
+                        return;
+                    }
+                    Ok(targets) => targets,
+                    Err(e) => {
+                        eprintln!(
+                            "{}",
+                            format!("Could not read target file {}: {}", path.display(), e).red()
+                        );
+                        return;
+                    }
+                }
             } else {
-                // clap's required `target` group guarantees `host` is present.
-                vec![host.expect("clap enforces --host when --stdin is absent")]
+                // With neither --stdin nor -iL, clap guarantees `host` is set.
+                vec![host.expect("clap enforces --host when --stdin/-iL are absent")]
             };
 
             // Resolve each target to an IP once, so the parallel scan below does

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 use indicatif::{ProgressBar, ProgressStyle};
-use ipnetwork::IpNetwork;
+use ipnetwork::{IpNetwork, NetworkSize};
 use std::collections::HashSet;
 use std::io::BufRead;
 use std::net::IpAddr;
@@ -60,26 +60,50 @@ pub fn progress_bar(total: u64, suffix: &str) -> ProgressBar {
     pb
 }
 
+/// Largest CIDR (by host count) expanded inline when a target line is a subnet.
+/// Wider blocks are kept as a single token rather than enumerated, so a stray
+/// `/8` in a target file cannot balloon into millions of entries.
+const MAX_TARGET_CIDR_HOSTS: u128 = 1 << 16; // 65_536 addresses
+
 /// Read scan targets from standard input, one per line.
 ///
 /// This is what turns two separate scans into a pipeline: the hosts an address
 /// scan discovers can be streamed straight into a port scan
 /// (`asphyxia as ... -o jsonl | asphyxia ps --stdin ...`).
 ///
-/// The input format is auto-detected per line so both a hand-written host list
-/// and the machine output of `asphyxia as` work without a flag:
+/// See [`read_targets`] for the per-line format that is accepted.
+pub fn read_targets_from_stdin() -> Vec<String> {
+    read_targets(std::io::stdin().lock())
+}
+
+/// Read scan targets from a file, one per line (`-iL`/`--target-file`).
+///
+/// A hand-maintained target list on disk is the repeatable counterpart to
+/// piping via `--stdin`. The per-line format is identical — see [`read_targets`].
+///
+/// Returns an error if the file cannot be opened or read.
+pub fn read_targets_from_file(path: &std::path::Path) -> std::io::Result<Vec<String>> {
+    let file = std::fs::File::open(path)?;
+    Ok(read_targets(std::io::BufReader::new(file)))
+}
+
+/// Parse scan targets from any line source.
+///
+/// The format is auto-detected per line so a hand-written list and the machine
+/// output of `asphyxia as` both work without a flag:
 ///
 /// * a line beginning with `{` or `[` is parsed as JSON and every `ip` field it
 ///   contains is taken as a target (covers `-o json` and `-o jsonl`);
+/// * a line in CIDR notation (e.g. `192.168.1.0/28`) is expanded into its
+///   individual addresses, up to [`MAX_TARGET_CIDR_HOSTS`];
 /// * any other non-empty line is treated as a bare host/IP.
 ///
 /// Blank lines are skipped, JSON lines that fail to parse are ignored, and
 /// duplicate targets are removed while preserving first-seen order.
-pub fn read_targets_from_stdin() -> Vec<String> {
-    let stdin = std::io::stdin();
+pub fn read_targets<R: BufRead>(reader: R) -> Vec<String> {
     let mut raw: Vec<String> = Vec::new();
 
-    for line in stdin.lock().lines() {
+    for line in reader.lines() {
         let Ok(line) = line else { continue };
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -87,6 +111,7 @@ pub fn read_targets_from_stdin() -> Vec<String> {
         }
         match trimmed.as_bytes().first() {
             Some(b'{') | Some(b'[') => extract_ips(trimmed, &mut raw),
+            _ if trimmed.contains('/') => expand_cidr(trimmed, &mut raw),
             _ => raw.push(trimmed.to_string()),
         }
     }
@@ -95,6 +120,32 @@ pub fn read_targets_from_stdin() -> Vec<String> {
     raw.into_iter()
         .filter(|host| seen.insert(host.clone()))
         .collect()
+}
+
+/// Expand a CIDR token into individual address strings, appending each to
+/// `out`. A token that is not a valid CIDR is pushed verbatim (it may be a
+/// hostname with a slash-path the user mistyped); a CIDR wider than
+/// [`MAX_TARGET_CIDR_HOSTS`] is kept as a single token with a warning.
+fn expand_cidr(token: &str, out: &mut Vec<String>) {
+    let Ok(network) = token.parse::<IpNetwork>() else {
+        out.push(token.to_string());
+        return;
+    };
+    let size: u128 = match network.size() {
+        NetworkSize::V4(n) => u128::from(n),
+        NetworkSize::V6(n) => n,
+    };
+    if size > MAX_TARGET_CIDR_HOSTS {
+        eprintln!(
+            "Not expanding {} ({} addresses, limit {}); passing it through as-is",
+            token, size, MAX_TARGET_CIDR_HOSTS
+        );
+        out.push(token.to_string());
+        return;
+    }
+    for ip in network.iter() {
+        out.push(ip.to_string());
+    }
 }
 
 /// Pull every `ip` string out of a JSON object or array of objects, appending
@@ -198,4 +249,60 @@ pub fn parse_subnet(subnet: &str) -> Result<IpNetwork, String> {
     subnet
         .parse::<IpNetwork>()
         .map_err(|_| format!("Invalid subnet format: {}", subnet))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn targets(input: &str) -> Vec<String> {
+        read_targets(Cursor::new(input))
+    }
+
+    #[test]
+    fn reads_bare_hosts_and_skips_blanks() {
+        assert_eq!(
+            targets("example.com\n\n  10.0.0.1  \n"),
+            vec!["example.com".to_string(), "10.0.0.1".to_string()]
+        );
+    }
+
+    #[test]
+    fn extracts_ip_from_json_and_jsonl_lines() {
+        let input = "{\"ip\":\"127.0.0.1\",\"status\":\"up\"}\n[{\"ip\":\"10.0.0.2\"}]\n";
+        assert_eq!(
+            targets(input),
+            vec!["127.0.0.1".to_string(), "10.0.0.2".to_string()]
+        );
+    }
+
+    #[test]
+    fn expands_a_cidr_line_into_addresses() {
+        // A /30 spans 4 addresses (network..broadcast inclusive).
+        let out = targets("192.168.1.0/30\n");
+        assert_eq!(
+            out,
+            vec![
+                "192.168.1.0".to_string(),
+                "192.168.1.1".to_string(),
+                "192.168.1.2".to_string(),
+                "192.168.1.3".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn deduplicates_while_preserving_first_seen_order() {
+        assert_eq!(
+            targets("10.0.0.1\n10.0.0.2\n10.0.0.1\n"),
+            vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()]
+        );
+    }
+
+    #[test]
+    fn oversized_cidr_is_passed_through_not_expanded() {
+        // A /8 is far larger than the expansion cap, so it stays a single token.
+        assert_eq!(targets("10.0.0.0/8\n"), vec!["10.0.0.0/8".to_string()]);
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -267,6 +267,83 @@ fn port_scan_grep_with_no_open_ports_emits_nothing() {
 }
 
 #[test]
+fn target_file_conflicts_with_host() {
+    // --target-file joins the same required target group as -t/--stdin.
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "--target-file",
+            "targets.txt",
+            "-s",
+            "80",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn target_file_reads_targets_from_disk() {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-targets-{}.txt", std::process::id()));
+    // One bare IP plus a /31 that expands to two addresses; port 1 is closed on
+    // all of them, so the run just proves the file was read and scanned.
+    std::fs::write(&path, "127.0.0.1\n127.0.0.2/31\n").unwrap();
+
+    asphyxia()
+        .args(["ps", "-i", path.to_str().unwrap(), "-s", "1", "-o", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn target_file_missing_reports_a_clear_error() {
+    asphyxia()
+        .args([
+            "ps",
+            "--target-file",
+            "/no/such/asphyxia-targets.txt",
+            "-s",
+            "1",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Could not read target file"));
+}
+
+#[test]
+fn config_supplies_defaults_that_flags_override() {
+    // A config setting the output to json applies when -o is absent; passing -o
+    // csv on the command line must win over it.
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-config-{}.toml", std::process::id()));
+    std::fs::write(&path, "output = \"json\"\ntimeout = 250\n").unwrap();
+
+    // No -o: the config's json format is used (empty array on a closed port).
+    asphyxia()
+        .env("ASPHYXIA_CONFIG", &path)
+        .args(["ps", "-t", "127.0.0.1", "-s", "1"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+
+    // Explicit -o csv overrides the config.
+    asphyxia()
+        .env("ASPHYXIA_CONFIG", &path)
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-o", "csv"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("ip,port,proto,status,latency_ms\n"));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn nmap_args_requires_the_nmap_flag() {
     // --nmap-args without --nmap is a parse error (clap `requires`).
     asphyxia()


### PR DESCRIPTION
## What

Closes #20. Two features for repeatable, mass runs.

### Target file input

- `-i` / `--target-file` (alias `--iL`) reads targets from a file: hosts, IPs, CIDRs (expanded up to 65 536 addresses), or the JSON/JSONL of `asphyxia as`, one per line. It joins the required target group next to `-t`/`--stdin`.
- The stdin reader is refactored into a generic `read_targets<R: BufRead>`, so file and stdin share the same auto-detection, dedup, and CIDR expansion.

### Config profiles

- `~/.asphyxia.toml` supplies defaults for `timeout`, `concurrency`, `retries`, and `output`. Unknown keys are rejected; an invalid file is warned about and ignored (never aborts a scan).
- **CLI flags always win.** Precedence is decided from clap's `ValueSource`: config only fills an option the user did not pass, so an explicit flag is never overridden.
- `ASPHYXIA_CONFIG` overrides the file path (used by the tests).

> Note: `-iL` cannot be a single short token in clap (multi-char shorts aren't supported), so the file flag is `-i` / `--target-file` with `--iL` as a long alias.

## Implementation

- `src/utils/mod.rs`: `read_targets`, `read_targets_from_file`, and `expand_cidr` (capped).
- New `src/config.rs`: `Config` (serde/TOML), `load`, `config_path`, `output_format`.
- `src/main.rs`: parse via `get_matches` + `from_arg_matches`, then `apply_config` merges config under CLI precedence.
- `src/cli/mod.rs`: `-i/--target-file` in the target group.
- New dependency: `toml` (Cargo.lock updated).

## Tests

- Unit: target reader (bare hosts, JSON/JSONL, CIDR expansion, dedup, oversized-CIDR passthrough); config (full/empty/partial parse, unknown-key rejection, invalid output name).
- CLI: `--target-file` conflicts with `-t`, reads targets from disk, missing-file error; config supplies a default output format that an explicit `-o` overrides.

## Docs

README (target-file examples, flag table, dedicated config section, features) and CLI `--help` updated.