### PR TITLE
Add rate limiting (--rate) and timing profiles (-T0..5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
+| `--rate <PPS>` | Cap connection attempts per second across the whole scan (0 or unset: no cap) |
+| `-T, --timing <0-5>` | Timing profile from `0` (paranoid) to `5` (insane), presetting timeout/concurrency/retries/rate |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
@@ -186,6 +188,8 @@ asphyxia as -s 10.0.0.0/22 --exclude-file skip.txt
 | `--timeout <MS>` | Per-connection timeout in milliseconds (default: 2000) |
 | `-c, --concurrency <N>` | Maximum concurrent connection attempts (default: 256) |
 | `--retries <N>` | Extra retries per probe on no answer/timeout (default: 0); refused ports are never retried |
+| `--rate <PPS>` | Cap connection attempts per second across the whole scan (0 or unset: no cap) |
+| `-T, --timing <0-5>` | Timing profile from `0` (paranoid) to `5` (insane), presetting timeout/concurrency/retries/rate |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
 
@@ -264,6 +268,7 @@ For repeated runs you can set defaults in `~/.asphyxia.toml` instead of retyping
 timeout     = 500     # per-connection timeout in ms
 concurrency = 512     # max concurrent connection attempts
 retries     = 1       # extra retries per probe on no answer
+rate        = 2000    # cap probes per second (0 or omitted = no cap)
 output      = "jsonl" # default output format: text | json | jsonl | csv | grep
 ```
 
@@ -278,6 +283,8 @@ To tune a scan:
 - **`--concurrency`** — raise it to finish large subnets faster (e.g. `--concurrency 512` for a `/22`); lower it if you want a gentler scan. Capped at 1024.
 - **`--timeout`** — on a responsive LAN a shorter timeout (e.g. `--timeout 500`) makes unreachable hosts give up much sooner.
 - **`--retries`** — on a lossy network (Wi-Fi, VPN, distant hosts) a dropped SYN makes an open port or live host look closed/down. A small value like `--retries 1` or `--retries 2` re-probes only when a probe got *no answer* (timeout/unreachable); a port that actively refuses the connection has already answered, so it is never retried and closed-port scans stay fast.
+- **`--rate`** — cap the number of connection attempts per second across the whole scan (e.g. `--rate 1000`). This bounds how hard the scan hits the network regardless of `--concurrency`: a single global pacer admits one probe per `1/rate` seconds, so highly-concurrent scans still stay under the limit. Leave it unset for no cap.
+- **`-T0`..`-T5`** — timing profiles that preset `--timeout`, `--concurrency`, `--retries`, and `--rate` in one shot, from `-T0` (paranoid: serial and slow) through `-T3` (the normal defaults) to `-T5` (insane: fastest, widest concurrency, no cap). Any individual flag still overrides the profile, e.g. `-T4 --timeout 800`.
 
 For example, a `/24` with the defaults completes in roughly one timeout window instead of serially walking every address.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -65,6 +65,10 @@ Examples:
   # Retry probes on a lossy network to cut false negatives (refused ports are not retried)
   asphyxia ps -t example.com --top-ports 1000 --retries 2
 
+  # Cap the scan rate, or pick a timing profile (0 paranoid .. 5 insane)
+  asphyxia ps -t example.com --all-ports --rate 1000
+  asphyxia ps -t example.com --top-ports 1000 -T4
+
   # Emit machine-readable output for a pipeline (text | json | jsonl | csv | grep)
   asphyxia ps -t example.com -s 22,80,443 -o jsonl
   asphyxia as -s 10.0.0.0/24 -o json
@@ -83,6 +87,8 @@ Required arguments:
     -a, --all-ports              Scan the entire port range (1-65535)
     --top-ports <N>              Scan the N most common TCP ports (up to 1000)
     --ports <NAME>               Scan a named port set (web, mail, db, remote, windows)
+    --rate <PPS>                 Cap connection attempts per second (0 = no cap)
+    -T, --timing <0-5>           Timing profile (paranoid..insane) presetting the tunables
     --timeout <MS>               Connection timeout in milliseconds (default: 2000)
 
   For address scanning (as):
@@ -174,6 +180,14 @@ pub enum Args {
         #[arg(long, value_name = "N", default_value_t = 0)]
         retries: u32,
 
+        /// Cap connection attempts per second across the whole scan (0 = no cap)
+        #[arg(long, value_name = "PPS")]
+        rate: Option<u32>,
+
+        /// Timing profile 0-5 (paranoid..insane) presetting timeout/concurrency/retries/rate
+        #[arg(short = 'T', long = "timing", value_name = "0-5", value_parser = clap::value_parser!(u8).range(0..=5))]
+        timing: Option<u8>,
+
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
         output: OutputFormat,
@@ -221,6 +235,14 @@ pub enum Args {
         #[arg(long, value_name = "N", default_value_t = 0)]
         retries: u32,
 
+        /// Cap connection attempts per second across the whole scan (0 = no cap)
+        #[arg(long, value_name = "PPS")]
+        rate: Option<u32>,
+
+        /// Timing profile 0-5 (paranoid..insane) presetting timeout/concurrency/retries/rate
+        #[arg(short = 'T', long = "timing", value_name = "0-5", value_parser = clap::value_parser!(u8).range(0..=5))]
+        timing: Option<u8>,
+
         /// Output format
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Text)]
         output: OutputFormat,
@@ -264,6 +286,14 @@ impl Args {
     pub fn retries(&self) -> u32 {
         match self {
             Args::PortScan { retries, .. } | Args::AddressScan { retries, .. } => *retries,
+        }
+    }
+
+    /// The probes-per-second cap, if any, regardless of which subcommand was
+    /// invoked.
+    pub fn rate(&self) -> Option<u32> {
+        match self {
+            Args::PortScan { rate, .. } | Args::AddressScan { rate, .. } => *rate,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub concurrency: Option<usize>,
     /// Extra retries per probe on no answer.
     pub retries: Option<u32>,
+    /// Probes-per-second cap across the whole scan (0 = no cap).
+    pub rate: Option<u32>,
     /// Output format name (`text`, `json`, `jsonl`, `csv`, `grep`).
     pub output: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,9 @@
 pub mod cli;
 pub mod config;
 pub mod output;
+pub mod rate;
 pub mod scanner;
+pub mod timing;
 pub mod utils;
 
 pub use config::Config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,11 @@ use rayon::prelude::*;
 use asphyxia::cli::Args;
 use asphyxia::config::Config;
 use asphyxia::output::{OutputFormat, ScanRecord, emit};
+use asphyxia::rate;
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
 use asphyxia::scanner::{address, nmap, port};
+use asphyxia::timing;
 use asphyxia::utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_file,
     read_targets_from_stdin,
@@ -115,13 +117,14 @@ fn scan_filtered(
     }
 }
 
-/// Apply `~/.asphyxia.toml` defaults to `args`, but only for options the user
-/// did not pass on the command line — so CLI flags always win over the config.
+/// Resolve the tunable scan options into `args`, layering three sources under a
+/// strict precedence: an explicit CLI flag beats a `-T` timing profile, which
+/// beats `~/.asphyxia.toml`, which beats the built-in defaults.
 ///
-/// The user's intent is read from clap's value source: an option whose value
-/// came from a `default_value` (not the command line) is eligible to be
-/// overridden by the config.
-fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
+/// "Explicit CLI flag" is read from clap's value source, so a value that merely
+/// came from a `default_value` is still eligible to be overridden by the config
+/// or a timing profile.
+fn resolve_options(args: &mut Args, matches: &ArgMatches, config: &Config) {
     let Some((_, sub)) = matches.subcommand() else {
         return;
     };
@@ -132,6 +135,8 @@ fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
             timeout,
             concurrency,
             retries,
+            rate,
+            timing,
             output,
             ..
         }
@@ -139,9 +144,12 @@ fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
             timeout,
             concurrency,
             retries,
+            rate,
+            timing,
             output,
             ..
         } => {
+            // Layer 1: config fills anything not set on the command line.
             if !from_cli("timeout")
                 && let Some(v) = config.timeout
             {
@@ -157,10 +165,31 @@ fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
             {
                 *retries = v;
             }
+            if !from_cli("rate") && config.rate.is_some() {
+                *rate = config.rate;
+            }
             if !from_cli("output")
                 && let Some(v) = config.output_format()
             {
                 *output = v;
+            }
+
+            // Layer 2: a -T profile overrides config/defaults, still yielding to
+            // any explicit flag.
+            if let Some(level) = *timing {
+                let profile = timing::profile(level);
+                if !from_cli("timeout") {
+                    *timeout = profile.timeout_ms;
+                }
+                if !from_cli("concurrency") {
+                    *concurrency = profile.concurrency;
+                }
+                if !from_cli("retries") {
+                    *retries = profile.retries;
+                }
+                if !from_cli("rate") {
+                    *rate = profile.rate;
+                }
             }
         }
     }
@@ -169,10 +198,15 @@ fn apply_config(args: &mut Args, matches: &ArgMatches, config: &Config) {
 fn main() {
     let matches = Args::command().get_matches();
     let mut args = Args::from_arg_matches(&matches).expect("clap builds valid Args");
-    apply_config(&mut args, &matches, &Config::load());
+    resolve_options(&mut args, &matches, &Config::load());
 
     // Size the global rayon pool for I/O-bound scanning before any scan runs.
     init_scan_pool(args.concurrency());
+
+    // Install the global rate limit (a no-op when unset or zero) before scanning.
+    if let Some(pps) = args.rate() {
+        rate::install(pps);
+    }
 
     let format = args.output_format();
     let output_file = args.output_file().cloned();

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,0 +1,132 @@
+//! Global rate limiting for scan probes.
+//!
+//! `--rate` caps how many connection attempts are made per second across the
+//! whole scan, so a large sweep does not overwhelm the network or trip a
+//! rate-limiter. Because probes fan out across the shared rayon pool, the limit
+//! is enforced by a single process-wide [`RateLimiter`] that every probe passes
+//! through: each call reserves the next evenly-spaced time slot and sleeps until
+//! it comes due.
+//!
+//! Like the thread pool, the limiter is installed once before the scan starts
+//! and consulted from the low-level probe paths via [`gate`]. When no limit is
+//! installed, [`gate`] is a cheap no-op.
+
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// A token-bucket-style pacer that admits at most one probe per `interval`.
+#[derive(Debug)]
+pub struct RateLimiter {
+    interval: Duration,
+    /// The earliest instant the next probe may start.
+    next: Mutex<Instant>,
+}
+
+impl RateLimiter {
+    /// Build a limiter admitting `pps` probes per second, or `None` when `pps`
+    /// is 0 (i.e. no limit).
+    pub fn per_second(pps: u32) -> Option<RateLimiter> {
+        if pps == 0 {
+            return None;
+        }
+        let interval = Duration::from_secs_f64(1.0 / f64::from(pps));
+        Some(RateLimiter {
+            interval,
+            next: Mutex::new(Instant::now()),
+        })
+    }
+
+    /// The spacing between admitted probes.
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// Block until this probe's reserved slot comes due.
+    pub fn acquire(&self) {
+        let scheduled = {
+            let mut next = self.next.lock().expect("rate limiter mutex poisoned");
+            let (scheduled, new_next) = reserve(Instant::now(), *next, self.interval);
+            *next = new_next;
+            scheduled
+        };
+        let wait = scheduled.saturating_duration_since(Instant::now());
+        if !wait.is_zero() {
+            thread::sleep(wait);
+        }
+    }
+}
+
+/// Reserve the next slot: a probe may start no earlier than `now` and no earlier
+/// than the previously reserved `next`. Returns the slot to run in and the new
+/// `next` (that slot plus one `interval`).
+fn reserve(now: Instant, next: Instant, interval: Duration) -> (Instant, Instant) {
+    let scheduled = next.max(now);
+    (scheduled, scheduled + interval)
+}
+
+/// The process-wide limiter, installed at most once via [`install`].
+static LIMITER: OnceLock<RateLimiter> = OnceLock::new();
+
+/// Install the global rate limit to `pps` probes per second. A `pps` of 0 (no
+/// limit) installs nothing. Calling more than once keeps the first limiter.
+pub fn install(pps: u32) {
+    if let Some(limiter) = RateLimiter::per_second(pps) {
+        let _ = LIMITER.set(limiter);
+    }
+}
+
+/// Pass through the global rate limiter, blocking until a slot is free. A no-op
+/// when no limit is installed.
+pub fn gate() {
+    if let Some(limiter) = LIMITER.get() {
+        limiter.acquire();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_limiter_for_zero_pps() {
+        assert!(RateLimiter::per_second(0).is_none());
+    }
+
+    #[test]
+    fn interval_is_the_reciprocal_of_the_rate() {
+        let limiter = RateLimiter::per_second(1000).unwrap();
+        assert_eq!(limiter.interval(), Duration::from_millis(1));
+        let limiter = RateLimiter::per_second(4).unwrap();
+        assert_eq!(limiter.interval(), Duration::from_millis(250));
+    }
+
+    #[test]
+    fn reserve_runs_immediately_when_the_slot_is_in_the_past() {
+        let now = Instant::now();
+        let past = now - Duration::from_secs(1);
+        let interval = Duration::from_millis(10);
+        let (scheduled, new_next) = reserve(now, past, interval);
+        assert_eq!(scheduled, now, "a stale slot runs now");
+        assert_eq!(new_next, now + interval);
+    }
+
+    #[test]
+    fn reserve_queues_behind_a_future_slot() {
+        let now = Instant::now();
+        let future = now + Duration::from_millis(50);
+        let interval = Duration::from_millis(10);
+        let (scheduled, new_next) = reserve(now, future, interval);
+        assert_eq!(scheduled, future, "must wait for the reserved slot");
+        assert_eq!(new_next, future + interval);
+    }
+
+    #[test]
+    fn consecutive_reservations_are_spaced_by_the_interval() {
+        let start = Instant::now();
+        let interval = Duration::from_millis(5);
+        let (s1, next) = reserve(start, start, interval);
+        let (s2, _) = reserve(start, next, interval);
+        assert_eq!(s2 - s1, interval);
+    }
+}

--- a/src/scanner/address.rs
+++ b/src/scanner/address.rs
@@ -121,6 +121,8 @@ fn probe_address(ip: IpAddr, timeout: Duration) -> Option<HostHit> {
 /// Make a single availability probe against one port. Returns `Some` when the
 /// host answers (open, or refused/reset) and `None` on silence.
 fn probe_port(ip: IpAddr, port: u16, timeout: Duration) -> Option<HostHit> {
+    // Respect the global rate limit (no-op when none is installed).
+    crate::rate::gate();
     let start = Instant::now();
     match TcpStream::connect_timeout(&SocketAddr::new(ip, port), timeout) {
         // Port is open: the host is unambiguously up.

--- a/src/scanner/port.rs
+++ b/src/scanner/port.rs
@@ -170,6 +170,8 @@ pub fn scan_port_with_retries(
 
 /// Make a single connection attempt to `host:port` and classify the outcome.
 fn probe_port(host: &str, port: u16, timeout: Duration) -> Probe {
+    // Respect the global rate limit (no-op when none is installed).
+    crate::rate::gate();
     let Some(socket_addr) = host_port(host, port)
         .to_socket_addrs()
         .ok()

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,114 @@
+//! Timing profiles (`-T0`..`-T5`), a familiar shorthand (à la nmap) for a whole
+//! speed/stealth posture instead of tuning `--timeout`, `--concurrency`,
+//! `--retries`, and `--rate` by hand.
+//!
+//! A profile is a set of presets. It fills in only the options the user did not
+//! set explicitly, so any individual flag still overrides the profile — the
+//! merge lives in `main`.
+
+/// The presets a timing profile expands into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Timing {
+    /// Per-connection timeout in milliseconds.
+    pub timeout_ms: u64,
+    /// Maximum concurrent connection attempts.
+    pub concurrency: usize,
+    /// Extra retries per probe on no answer.
+    pub retries: u32,
+    /// Optional probes-per-second cap (`None` = unlimited).
+    pub rate: Option<u32>,
+}
+
+/// The highest supported timing level (`-T5`).
+pub const MAX_LEVEL: u8 = 5;
+
+/// The preset bundle for a timing `level` (`0`..=`5`). Levels run from `0`
+/// (paranoid: slow, serial, heavily rate-limited) to `5` (insane: fastest,
+/// widest concurrency, no rate cap). Levels above [`MAX_LEVEL`] clamp to it.
+pub fn profile(level: u8) -> Timing {
+    match level {
+        // Paranoid: one probe at a time, slow, tightly rate-limited.
+        0 => Timing {
+            timeout_ms: 5000,
+            concurrency: 1,
+            retries: 3,
+            rate: Some(10),
+        },
+        // Sneaky.
+        1 => Timing {
+            timeout_ms: 4000,
+            concurrency: 4,
+            retries: 2,
+            rate: Some(100),
+        },
+        // Polite: gentle on the target, still rate-limited.
+        2 => Timing {
+            timeout_ms: 3000,
+            concurrency: 16,
+            retries: 1,
+            rate: Some(1000),
+        },
+        // Normal: the tool's out-of-the-box defaults.
+        3 => Timing {
+            timeout_ms: 2000,
+            concurrency: 256,
+            retries: 0,
+            rate: None,
+        },
+        // Aggressive: fast, for responsive networks.
+        4 => Timing {
+            timeout_ms: 1000,
+            concurrency: 512,
+            retries: 0,
+            rate: None,
+        },
+        // Insane (5 and anything higher): maximum speed.
+        _ => Timing {
+            timeout_ms: 500,
+            concurrency: 1024,
+            retries: 0,
+            rate: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levels_get_faster_as_they_rise() {
+        // Timeout shrinks and concurrency grows monotonically from T0 to T5.
+        let profiles: Vec<Timing> = (0..=MAX_LEVEL).map(profile).collect();
+        for pair in profiles.windows(2) {
+            assert!(
+                pair[1].timeout_ms <= pair[0].timeout_ms,
+                "timeout should not increase with level"
+            );
+            assert!(
+                pair[1].concurrency >= pair[0].concurrency,
+                "concurrency should not decrease with level"
+            );
+        }
+    }
+
+    #[test]
+    fn paranoid_is_serial_and_rate_limited() {
+        let t0 = profile(0);
+        assert_eq!(t0.concurrency, 1);
+        assert!(t0.rate.is_some());
+        assert!(t0.retries > 0);
+    }
+
+    #[test]
+    fn insane_is_unlimited_and_widest() {
+        let t5 = profile(5);
+        assert_eq!(t5.rate, None);
+        assert_eq!(t5.concurrency, 1024);
+    }
+
+    #[test]
+    fn levels_above_max_clamp_to_insane() {
+        assert_eq!(profile(9), profile(MAX_LEVEL));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -218,6 +218,74 @@ fn retries_flag_rejects_non_numeric() {
 }
 
 #[test]
+fn timing_profile_out_of_range_is_rejected() {
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-T", "9"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn timing_profile_is_accepted() {
+    // -T4 is a valid preset; a closed port keeps the run fast.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "-T", "4", "-o", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn rate_flag_is_accepted() {
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1",
+            "--rate",
+            "1000",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
+fn rate_limit_paces_multiple_probes() {
+    use std::time::Instant;
+    // Scan several closed ports on loopback at 20 probes/sec. Refused ports
+    // return instantly, so without pacing this finishes in milliseconds; the
+    // rate limit forces it to take at least a few slots (~200ms for 5 probes).
+    let start = Instant::now();
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1,2,3,4,5",
+            "--rate",
+            "20",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success();
+    let elapsed = start.elapsed();
+    // 5 probes at 20/sec span 4 intervals of 50ms = 200ms minimum for the
+    // probes themselves; allow generous slack for process startup jitter.
+    assert!(
+        elapsed >= std::time::Duration::from_millis(150),
+        "rate limit should pace the scan, took {:?}",
+        elapsed
+    );
+}
+
+#[test]
 fn concurrency_flag_rejects_non_numeric() {
     asphyxia()
         .args(["as", "-s", "192.168.1.0/24", "--concurrency", "lots"])


### PR DESCRIPTION
## What

Closes #15. Two ways to control scan tempo.

### `--rate <PPS>`

A process-wide token-bucket pacer that every probe passes through, capping connection attempts per second across the whole scan — independent of `--concurrency`, so even a highly-parallel scan stays under the limit. `0` or unset means no cap.

### Timing profiles `-T0`..`-T5`

Nmap-style shorthand that presets `--timeout`, `--concurrency`, `--retries`, and `--rate` in one shot, from `-T0` (paranoid: serial, slow, tightly rate-limited) through `-T3` (the normal defaults) to `-T5` (insane: fastest, widest concurrency, no cap).

## Precedence

Strict and explicit, resolved from clap's `ValueSource`:

**explicit CLI flag → `-T` profile → `~/.asphyxia.toml` → built-in default**

So `-T4 --timeout 800` uses the aggressive profile but with your timeout; a config `rate` applies unless a profile or flag overrides it.

## Implementation

- New `src/rate.rs`: `RateLimiter` (evenly-spaced slot reservation), a global `install`/`gate`, consulted from `port::probe_port` and `address::probe_port`. The slot math is a pure `reserve()` for testing.
- New `src/timing.rs`: `profile(level)` preset bundles.
- `src/main.rs`: `resolve_options` layers config then timing under CLI precedence; the limiter is installed before scanning.
- `src/cli/mod.rs`: `--rate` and `-T/--timing` (range-validated 0..=5) on both subcommands; `src/config.rs` gains a `rate` field.

## Tests

- Unit: limiter interval/zero-pps, `reserve` slot math (stale/future/spacing); timing profiles monotonic across levels, paranoid serial+limited, insane unlimited, clamp above max.
- CLI: `-T` range rejection and acceptance, `--rate` accepted, and a timing assertion that `--rate 20` actually paces a 5-probe scan to ≥150 ms.

## Docs

README (flag tables, tuning section, config example) and CLI `--help` updated.