### PR TITLE
Add UDP port scanning (--udp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ asphyxia ps -t example.com --all-ports
 asphyxia ps -t example.com --top-ports 100
 asphyxia ps -t example.com --top-ports 1000
 
+# Scan UDP ports instead of TCP (DNS, NTP, SNMP, …)
+asphyxia ps -t example.com -s 53,123,161 --udp
+
 # Scan a named port set (web, mail, db, remote, windows)
 asphyxia ps -t example.com --ports web
 
@@ -138,6 +141,7 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `-r, --range <START> <END>` | Scan an inclusive range of ports |
 | `-s, --specific <PORTS>` | Scan specific comma-separated ports |
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
+| `-u, --udp` | Scan UDP ports instead of TCP (results are `open` or `open\|filtered`) |
 | `--top-ports <N>` | Scan the `N` most common TCP ports (frequency-ordered, up to 1000) |
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--exclude-ports <PORTS>` | Remove these comma-separated ports from the scan set |
@@ -151,6 +155,21 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `-T, --timing <0-5>` | Timing profile from `0` (paranoid) to `5` (insane), presetting timeout/concurrency/retries/rate |
 | `-o, --output <FORMAT>` | Output format: `text` (default), `json`, `jsonl`, `csv`, or `grep` |
 | `--output-file <PATH>` (`--oF`) | Write machine-readable output to a file instead of stdout |
+
+#### UDP scanning (`--udp`)
+
+Pass `-u`/`--udp` to probe UDP ports instead of TCP. UDP has no handshake, so results are inherently less certain than TCP and use two statuses:
+
+- **`open`** — the port sent a reply. For a few well-known ports asphyxia sends a protocol-specific probe (a DNS query on 53, an NTP client request on 123) to coax a reply and turn what would otherwise be a guess into a definite `open`.
+- **`open|filtered`** — the port stayed silent within the timeout. The datagram may have been dropped, the service may not answer this particular probe, or a firewall may be filtering it — these are indistinguishable without elevated privileges.
+
+A port that answers with an ICMP port-unreachable is **closed** and is simply not reported (like a closed TCP port). In machine output the `proto` field is `"udp"` and `status` is `"open"` or `"open|filtered"`. Because silent ports wait out the full `--timeout`, UDP scans of many ports are slower than TCP — narrow the port set (e.g. `-s 53,123,161,500` or `--top-ports`) and consider `--retries 1` on a lossy link.
+
+```bash
+asphyxia ps -t 192.168.1.1 -s 53,123,161 --udp
+asphyxia ps -t 192.168.1.1 -s 53,123,161 --udp -o jsonl
+# {"ip":"192.168.1.1","port":53,"proto":"udp","latency_ms":4,"status":"open"}
+```
 
 ### Address scanning (`as`)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,9 @@ Examples:
   asphyxia ps -t example.com --top-ports 100
   asphyxia ps -t example.com --ports web
 
+  # Scan UDP ports instead of TCP (open or open|filtered)
+  asphyxia ps -t example.com -s 53,123,161 --udp
+
   # Find open ports fast, then hand them to nmap for a deep dive
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
@@ -87,6 +90,7 @@ Required arguments:
     -a, --all-ports              Scan the entire port range (1-65535)
     --top-ports <N>              Scan the N most common TCP ports (up to 1000)
     --ports <NAME>               Scan a named port set (web, mail, db, remote, windows)
+    -u, --udp                    Scan UDP ports instead of TCP (open or open|filtered)
     --rate <PPS>                 Cap connection attempts per second (0 = no cap)
     -T, --timing <0-5>           Timing profile (paranoid..insane) presetting the tunables
     --timeout <MS>               Connection timeout in milliseconds (default: 2000)
@@ -154,6 +158,10 @@ pub enum Args {
         /// For known CDN/WAF targets, scan only 80 and 443 instead of the full set
         #[arg(long = "exclude-cdn")]
         exclude_cdn: bool,
+
+        /// Scan UDP ports instead of TCP (results are open or open|filtered)
+        #[arg(short = 'u', long = "udp")]
+        udp: bool,
 
         /// After the scan, run nmap on each host's open ports for a deep dive
         #[arg(long = "nmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,9 @@ pub use scanner::address::{
 pub use scanner::exclude::ExcludeSet;
 pub use scanner::nmap::{nmap_args, run_nmap, split_extra_args};
 /// Re-export commonly used types and functions
-pub use scanner::port::{PortHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries};
+pub use scanner::port::{
+    PortHit, UdpHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries, scan_udp_port,
+};
 pub use utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets,
     read_targets_from_file, read_targets_from_stdin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,16 @@ use asphyxia::utils::{
     read_targets_from_stdin,
 };
 
+/// One reportable port result, normalised across TCP and UDP so the output
+/// path does not care which protocol produced it.
+struct Finding {
+    port: u16,
+    latency: Duration,
+    /// `"open"` (TCP, or a UDP port that replied) or `"open|filtered"` (a silent
+    /// UDP port).
+    status: &'static str,
+}
+
 /// Mark every address as up without probing, for `-Pn` (skip discovery). The
 /// latency is zero since no probe was sent.
 fn all_up(addrs: Vec<IpAddr>) -> Vec<address::HostHit> {
@@ -55,11 +65,7 @@ fn build_exclude_set(specs: &[String], file: Option<&Path>) -> Result<ExcludeSet
 ///
 /// A missing nmap binary is reported once with an install hint rather than
 /// failing per host; any other spawn error is surfaced per host.
-fn run_nmap_handoff(
-    resolved: &[(String, String)],
-    opened: &[(usize, port::PortHit)],
-    extra: &[String],
-) {
+fn run_nmap_handoff(resolved: &[(String, String)], opened: &[(usize, Finding)], extra: &[String]) {
     use std::io::ErrorKind;
 
     // `opened` is already sorted by (host index, port), so consecutive runs of
@@ -224,12 +230,14 @@ fn main() {
             port_set,
             exclude_ports,
             exclude_cdn,
+            udp,
             nmap,
             nmap_args,
             timeout,
             ..
         } => {
             let timeout = Some(Duration::from_millis(timeout));
+            let proto = if udp { "udp" } else { "tcp" };
 
             let mut ports: Vec<u16> = if all_ports {
                 (1..=u16::MAX).collect()
@@ -388,25 +396,41 @@ fn main() {
 
             let pb = progress_bar(jobs.len() as u64, "ports scanned");
 
-            let mut opened: Vec<(usize, port::PortHit)> = jobs
+            // Probe every (host, port) pair. TCP yields only open ports; UDP also
+            // reports open|filtered (silent) ports, since silence is meaningful.
+            let mut opened: Vec<(usize, Finding)> = jobs
                 .into_par_iter()
                 .filter_map(|(i, port)| {
-                    let hit =
-                        port::scan_port_with_retries(resolved[i].1.clone(), port, timeout, retries);
+                    let ip = resolved[i].1.clone();
+                    let finding = if udp {
+                        port::scan_udp_port(ip, port, timeout, retries).map(|hit| Finding {
+                            port: hit.port,
+                            latency: hit.latency,
+                            status: if hit.open { "open" } else { "open|filtered" },
+                        })
+                    } else {
+                        port::scan_port_with_retries(ip, port, timeout, retries).map(|hit| {
+                            Finding {
+                                port: hit.port,
+                                latency: hit.latency,
+                                status: "open",
+                            }
+                        })
+                    };
                     pb.inc(1);
-                    hit.map(|hit| (i, hit))
+                    finding.map(|f| (i, f))
                 })
                 .collect();
 
             pb.finish_with_message("Scan completed");
 
-            opened.sort_by_key(|(i, hit)| (*i, hit.port));
+            opened.sort_by_key(|(i, f)| (*i, f.port));
 
             match format {
                 OutputFormat::Text => {
                     if !opened.is_empty() {
                         let mut current: Option<usize> = None;
-                        for (i, hit) in &opened {
+                        for (i, f) in &opened {
                             let host = &resolved[*i].0;
                             if current != Some(*i) {
                                 println!(
@@ -416,11 +440,22 @@ fn main() {
                                 );
                                 current = Some(*i);
                             }
-                            println!(
-                                "{}:{}",
-                                host.bright_cyan(),
-                                hit.port.to_string().bright_green()
-                            );
+                            // Show the status only when it carries information
+                            // beyond "open" (i.e. UDP open|filtered).
+                            if f.status == "open" {
+                                println!(
+                                    "{}:{}",
+                                    host.bright_cyan(),
+                                    f.port.to_string().bright_green()
+                                );
+                            } else {
+                                println!(
+                                    "{}:{} {}",
+                                    host.bright_cyan(),
+                                    f.port.to_string().bright_green(),
+                                    f.status.yellow()
+                                );
+                            }
                         }
                     } else {
                         println!("\n{}", "No open ports found 😕".yellow());
@@ -431,12 +466,12 @@ fn main() {
                 _ => {
                     let records: Vec<ScanRecord> = opened
                         .iter()
-                        .map(|(i, hit)| ScanRecord {
+                        .map(|(i, f)| ScanRecord {
                             ip: resolved[*i].1.clone(),
-                            port: Some(hit.port),
-                            proto: "tcp",
-                            latency_ms: hit.latency.as_millis(),
-                            status: "open",
+                            port: Some(f.port),
+                            proto,
+                            latency_ms: f.latency.as_millis(),
+                            status: f.status,
                         })
                         .collect();
                     if let Err(e) = emit(&records, format, output_file.as_deref()) {

--- a/src/scanner/port.rs
+++ b/src/scanner/port.rs
@@ -195,6 +195,168 @@ fn probe_port(host: &str, port: u16, timeout: Duration) -> Probe {
     }
 }
 
+// ---------------------------------------------------------------------------
+// UDP scanning
+// ---------------------------------------------------------------------------
+
+/// An observed UDP port together with how long the probe took.
+///
+/// UDP has no handshake, so a port is either provably `open` (it sent a reply)
+/// or `open|filtered` (it stayed silent — the datagram may have been dropped, or
+/// the service simply does not answer this probe). A port that answers with an
+/// ICMP port-unreachable is closed and is not reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UdpHit {
+    pub port: u16,
+    pub latency: Duration,
+    /// `true` when the port replied (`open`), `false` when it was silent
+    /// (`open|filtered`).
+    pub open: bool,
+}
+
+/// The classified outcome of a single UDP probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UdpProbe {
+    /// The port replied — it is open.
+    Open,
+    /// ICMP port-unreachable came back — the port is closed.
+    Closed,
+    /// No reply within the timeout — open or filtered, indistinguishable
+    /// without privileges.
+    OpenFiltered,
+}
+
+/// Scan a UDP `port`, retrying a silent probe up to `retries` extra times (a
+/// dropped datagram can otherwise masquerade as `open|filtered`).
+///
+/// Returns `None` for a closed port (ICMP unreachable), and `Some(UdpHit)` for
+/// an open or open|filtered port. For a handful of well-known ports a
+/// protocol-specific payload is sent to coax a reply and cut down on
+/// `open|filtered` results; other ports get an empty datagram.
+///
+/// # Examples
+///
+/// ```no_run
+/// use asphyxia::scanner::port::scan_udp_port;
+///
+/// if let Some(hit) = scan_udp_port("1.1.1.1".to_string(), 53, None, 1) {
+///     println!("udp/{} is {}", hit.port, if hit.open { "open" } else { "open|filtered" });
+/// }
+/// ```
+pub fn scan_udp_port(
+    host: String,
+    port: u16,
+    timeout: Option<Duration>,
+    retries: u32,
+) -> Option<UdpHit> {
+    let timeout = timeout.unwrap_or(CONNECT_TIMEOUT);
+    let start = Instant::now();
+
+    // Retry only the ambiguous "silent" outcome; a reply or an ICMP unreachable
+    // is a definitive answer.
+    let mut outcome = UdpProbe::OpenFiltered;
+    for _ in 0..=retries {
+        outcome = probe_udp(&host, port, timeout);
+        if outcome != UdpProbe::OpenFiltered {
+            break;
+        }
+    }
+
+    match outcome {
+        UdpProbe::Open => Some(UdpHit {
+            port,
+            latency: start.elapsed(),
+            open: true,
+        }),
+        UdpProbe::OpenFiltered => Some(UdpHit {
+            port,
+            latency: start.elapsed(),
+            open: false,
+        }),
+        UdpProbe::Closed => None,
+    }
+}
+
+/// Send one UDP datagram and classify what comes back.
+fn probe_udp(host: &str, port: u16, timeout: Duration) -> UdpProbe {
+    use std::net::UdpSocket;
+
+    // Respect the global rate limit (no-op when none is installed).
+    crate::rate::gate();
+
+    let Some(target) = host_port(host, port)
+        .to_socket_addrs()
+        .ok()
+        .and_then(|mut addrs| addrs.next())
+    else {
+        // Unresolvable: nothing to probe.
+        return UdpProbe::Closed;
+    };
+
+    // Bind an ephemeral local socket in the target's address family.
+    let bind_addr = if target.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    };
+    let Ok(socket) = UdpSocket::bind(bind_addr) else {
+        return UdpProbe::OpenFiltered;
+    };
+    if socket.connect(target).is_err() {
+        return UdpProbe::OpenFiltered;
+    }
+    if socket.set_read_timeout(Some(timeout)).is_err() {
+        return UdpProbe::OpenFiltered;
+    }
+    if socket.send(&udp_probe_payload(port)).is_err() {
+        return UdpProbe::OpenFiltered;
+    }
+
+    let mut buf = [0u8; 512];
+    classify_udp(socket.recv(&mut buf))
+}
+
+/// Map a UDP `recv` result to a probe outcome.
+fn classify_udp(result: std::io::Result<usize>) -> UdpProbe {
+    match result {
+        // Any reply proves the port is open.
+        Ok(_) => UdpProbe::Open,
+        // A connected UDP socket surfaces ICMP port-unreachable as a refusal.
+        Err(e) if e.kind() == ErrorKind::ConnectionRefused => UdpProbe::Closed,
+        // Timeout or would-block: no answer, so open or filtered.
+        Err(_) => UdpProbe::OpenFiltered,
+    }
+}
+
+/// A protocol-specific probe payload for `port`, or an empty datagram when no
+/// specific probe is known. A tailored payload is far more likely to elicit a
+/// reply, which turns an `open|filtered` guess into a definite `open`.
+fn udp_probe_payload(port: u16) -> Vec<u8> {
+    match port {
+        // DNS: a standard query for the root NS record (RD set).
+        53 => vec![
+            0x12, 0x34, // transaction id
+            0x01, 0x00, // flags: recursion desired
+            0x00, 0x01, // qdcount = 1
+            0x00, 0x00, // ancount
+            0x00, 0x00, // nscount
+            0x00, 0x00, // arcount
+            0x00, // qname: root
+            0x00, 0x02, // qtype: NS
+            0x00, 0x01, // qclass: IN
+        ],
+        // NTP: a 48-byte client request (LI=0, VN=3, mode=3 client).
+        123 => {
+            let mut pkt = vec![0u8; 48];
+            pkt[0] = 0x1b;
+            pkt
+        }
+        // Others: an empty datagram is enough to trigger an ICMP unreachable
+        // from a closed port.
+        _ => Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -295,5 +457,67 @@ mod tests {
             Probe::NoAnswer
         });
         assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn udp_classification_maps_recv_outcomes() {
+        use std::io::{Error, ErrorKind};
+        assert_eq!(classify_udp(Ok(12)), UdpProbe::Open);
+        assert_eq!(
+            classify_udp(Err(Error::from(ErrorKind::ConnectionRefused))),
+            UdpProbe::Closed
+        );
+        assert_eq!(
+            classify_udp(Err(Error::from(ErrorKind::WouldBlock))),
+            UdpProbe::OpenFiltered
+        );
+        assert_eq!(
+            classify_udp(Err(Error::from(ErrorKind::TimedOut))),
+            UdpProbe::OpenFiltered
+        );
+    }
+
+    #[test]
+    fn dns_payload_is_a_wellformed_query_header() {
+        let dns = udp_probe_payload(53);
+        assert!(!dns.is_empty());
+        // qdcount == 1 lives in bytes 4..6.
+        assert_eq!(&dns[4..6], &[0x00, 0x01]);
+        // Query terminates with root name + qtype NS + qclass IN.
+        assert_eq!(&dns[dns.len() - 5..], &[0x00, 0x00, 0x02, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn ntp_payload_is_a_48_byte_client_request() {
+        let ntp = udp_probe_payload(123);
+        assert_eq!(ntp.len(), 48);
+        assert_eq!(ntp[0], 0x1b);
+    }
+
+    #[test]
+    fn unknown_ports_get_an_empty_payload() {
+        assert!(udp_probe_payload(4444).is_empty());
+    }
+
+    #[test]
+    fn udp_scan_reports_open_when_a_local_server_replies() {
+        use std::net::UdpSocket;
+        use std::thread;
+
+        // A local UDP echo server: it replies to the first datagram, which must
+        // make the probe classify the port as open.
+        let server = UdpSocket::bind("127.0.0.1:0").expect("bind server");
+        let port = server.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let mut buf = [0u8; 512];
+            if let Ok((n, peer)) = server.recv_from(&mut buf) {
+                let _ = server.send_to(&buf[..n], peer);
+            }
+        });
+
+        let hit = scan_udp_port("127.0.0.1".to_string(), port, TEST_TIMEOUT, 0)
+            .expect("a replying port is open|filtered or open, never closed");
+        assert!(hit.open, "a replying UDP port must be reported open");
+        let _ = handle.join();
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -412,6 +412,30 @@ fn config_supplies_defaults_that_flags_override() {
 }
 
 #[test]
+fn udp_scan_reports_proto_udp_in_json() {
+    // A UDP probe to a closed loopback port typically draws an ICMP
+    // port-unreachable (closed → not reported) or stays silent
+    // (open|filtered). Either way the run succeeds and, when anything is
+    // reported, it is tagged proto "udp" — never "tcp".
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "9",
+            "--udp",
+            "--timeout",
+            "300",
+            "-o",
+            "jsonl",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"proto\":\"tcp\"").not());
+}
+
+#[test]
 fn nmap_args_requires_the_nmap_flag() {
     // --nmap-args without --nmap is a parse error (clap `requires`).
     asphyxia()


### PR DESCRIPTION
## What

Closes #14.

Only TCP was scannable, so UDP-only services (DNS, NTP, SNMP, mDNS, …) were invisible. Adds `-u`/`--udp` to probe UDP ports.

## Semantics

UDP has no handshake, so results are inherently less certain than TCP:

- **`open`** — the port replied. For a few well-known ports asphyxia sends a protocol-specific payload (a DNS query on 53, an NTP client request on 123) to coax a reply and turn an `open|filtered` guess into a definite `open`.
- **`open|filtered`** — silent within the timeout (dropped datagram, non-answering service, or a filtering firewall — indistinguishable unprivileged).
- **closed** — an ICMP port-unreachable came back; not reported, like a closed TCP port.

Silent probes honour `--retries`. In machine output `proto` is `"udp"` and `status` is `"open"` or `"open|filtered"`.

## Implementation

- `src/scanner/port.rs`: `scan_udp_port` with a `UdpProbe` classification (`Open`/`Closed`/`OpenFiltered`), a pure `classify_udp` for the recv result, and `udp_probe_payload` for the per-port probes. Rate-limited via the same `rate::gate` as TCP.
- `src/main.rs`: a shared `Finding { port, latency, status }` normalises TCP and UDP so the text/machine output path is protocol-agnostic; `proto` is threaded through.
- `src/cli/mod.rs`: `-u/--udp` on `ps`.

## Tests

- Unit: `classify_udp` for reply/refused/timeout/would-block; DNS and NTP payload shapes and empty default; and an end-to-end probe against a local UDP echo server that must report `open`.
- CLI: `--udp` output is tagged `proto "udp"`, never `"tcp"`.

## Docs

README (UDP semantics section, examples, flag table) and CLI `--help` updated.