### PR TITLE
Add service/version detection and banner grabbing (--sV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ asphyxia ps -t example.com --top-ports 1000
 # Scan UDP ports instead of TCP (DNS, NTP, SNMP, …)
 asphyxia ps -t example.com -s 53,123,161 --udp
 
+# Grab banners and identify services on open ports
+asphyxia ps -t example.com -s 22,80,443 --sV
+
 # Scan a named port set (web, mail, db, remote, windows)
 asphyxia ps -t example.com --ports web
 
@@ -142,6 +145,7 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `-s, --specific <PORTS>` | Scan specific comma-separated ports |
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
 | `-u, --udp` | Scan UDP ports instead of TCP (results are `open` or `open\|filtered`) |
+| `--sV` (`--banner`) | Grab banners and identify the service on each open TCP port |
 | `--top-ports <N>` | Scan the `N` most common TCP ports (frequency-ordered, up to 1000) |
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--exclude-ports <PORTS>` | Remove these comma-separated ports from the scan set |
@@ -169,6 +173,18 @@ A port that answers with an ICMP port-unreachable is **closed** and is simply no
 asphyxia ps -t 192.168.1.1 -s 53,123,161 --udp
 asphyxia ps -t 192.168.1.1 -s 53,123,161 --udp -o jsonl
 # {"ip":"192.168.1.1","port":53,"proto":"udp","latency_ms":4,"status":"open"}
+```
+
+#### Service & version detection (`--sV`)
+
+Add `--sV` (alias `--banner`) to identify what is listening on each open TCP port. For every open port asphyxia grabs a small banner — reading whatever the service announces on connect (SSH, SMTP, FTP), and nudging quiet services with a minimal HTTP request — then matches it against a compact set of built-in signatures (SSH, HTTP, SMTP, FTP, POP3/IMAP, MySQL, Redis, …). When no banner can be matched it falls back to the well-known name for the port.
+
+This is a lightweight identifier, not a full nmap-service-probes database — for exhaustive detection, combine it with `--nmap`. In machine output the `service` and `banner` fields are added to each record (omitted when nothing was found); in text output they are shown next to the port.
+
+```bash
+asphyxia ps -t example.com -s 22,80,443 --sV
+asphyxia ps -t example.com --top-ports 100 --sV -o jsonl
+# {"ip":"93.184.216.34","port":22,"proto":"tcp","latency_ms":7,"status":"open","service":"ssh","banner":"SSH-2.0-OpenSSH_9.6"}
 ```
 
 ### Address scanning (`as`)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,6 +30,9 @@ Examples:
   # Scan UDP ports instead of TCP (open or open|filtered)
   asphyxia ps -t example.com -s 53,123,161 --udp
 
+  # Grab banners and identify services on open ports
+  asphyxia ps -t example.com -s 22,80,443 --sV
+
   # Find open ports fast, then hand them to nmap for a deep dive
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
@@ -91,6 +94,7 @@ Required arguments:
     --top-ports <N>              Scan the N most common TCP ports (up to 1000)
     --ports <NAME>               Scan a named port set (web, mail, db, remote, windows)
     -u, --udp                    Scan UDP ports instead of TCP (open or open|filtered)
+    --sV                         Grab banners and identify the service on each open port
     --rate <PPS>                 Cap connection attempts per second (0 = no cap)
     -T, --timing <0-5>           Timing profile (paranoid..insane) presetting the tunables
     --timeout <MS>               Connection timeout in milliseconds (default: 2000)
@@ -162,6 +166,10 @@ pub enum Args {
         /// Scan UDP ports instead of TCP (results are open or open|filtered)
         #[arg(short = 'u', long = "udp")]
         udp: bool,
+
+        /// Grab banners and identify the service on each open port (TCP only)
+        #[arg(long = "sV", visible_alias = "banner")]
+        service_detection: bool,
 
         /// After the scan, run nmap on each host's open ports for a deep dive
         #[arg(long = "nmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub use scanner::nmap::{nmap_args, run_nmap, split_extra_args};
 pub use scanner::port::{
     PortHit, UdpHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries, scan_udp_port,
 };
+pub use scanner::service::{detect as detect_service, match_service, service_by_port};
 pub use utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets,
     read_targets_from_file, read_targets_from_stdin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use asphyxia::output::{OutputFormat, ScanRecord, emit};
 use asphyxia::rate;
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
-use asphyxia::scanner::{address, nmap, port};
+use asphyxia::scanner::{address, nmap, port, service};
 use asphyxia::timing;
 use asphyxia::utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_file,
@@ -28,6 +28,10 @@ struct Finding {
     /// `"open"` (TCP, or a UDP port that replied) or `"open|filtered"` (a silent
     /// UDP port).
     status: &'static str,
+    /// Detected service, when `--sV` is on and identification succeeded.
+    service: Option<String>,
+    /// Raw service banner, when `--sV` is on and one was grabbed.
+    banner: Option<String>,
 }
 
 /// Mark every address as up without probing, for `-Pn` (skip discovery). The
@@ -231,13 +235,17 @@ fn main() {
             exclude_ports,
             exclude_cdn,
             udp,
+            service_detection,
             nmap,
             nmap_args,
             timeout,
             ..
         } => {
-            let timeout = Some(Duration::from_millis(timeout));
+            let connect_timeout = Duration::from_millis(timeout);
+            let timeout = Some(connect_timeout);
             let proto = if udp { "udp" } else { "tcp" };
+            // Service detection only makes sense over a TCP stream.
+            let detect_service = service_detection && !udp;
 
             let mut ports: Vec<u16> = if all_ports {
                 (1..=u16::MAX).collect()
@@ -407,15 +415,28 @@ fn main() {
                             port: hit.port,
                             latency: hit.latency,
                             status: if hit.open { "open" } else { "open|filtered" },
+                            service: None,
+                            banner: None,
                         })
                     } else {
-                        port::scan_port_with_retries(ip, port, timeout, retries).map(|hit| {
-                            Finding {
-                                port: hit.port,
-                                latency: hit.latency,
-                                status: "open",
-                            }
-                        })
+                        port::scan_port_with_retries(ip.clone(), port, timeout, retries).map(
+                            |hit| {
+                                // For an open TCP port, optionally grab a banner and
+                                // identify the service.
+                                let (service, banner) = if detect_service {
+                                    service::detect(&ip, hit.port, connect_timeout)
+                                } else {
+                                    (None, None)
+                                };
+                                Finding {
+                                    port: hit.port,
+                                    latency: hit.latency,
+                                    status: "open",
+                                    service,
+                                    banner,
+                                }
+                            },
+                        )
                     };
                     pb.inc(1);
                     finding.map(|f| (i, f))
@@ -440,22 +461,25 @@ fn main() {
                                 );
                                 current = Some(*i);
                             }
-                            // Show the status only when it carries information
-                            // beyond "open" (i.e. UDP open|filtered).
-                            if f.status == "open" {
-                                println!(
-                                    "{}:{}",
-                                    host.bright_cyan(),
-                                    f.port.to_string().bright_green()
-                                );
-                            } else {
-                                println!(
-                                    "{}:{} {}",
-                                    host.bright_cyan(),
-                                    f.port.to_string().bright_green(),
-                                    f.status.yellow()
-                                );
+                            // Base line is host:port; annotate with the status
+                            // when it carries information beyond "open" (UDP
+                            // open|filtered), and with the service/banner when
+                            // --sV identified one.
+                            let mut line = format!(
+                                "{}:{}",
+                                host.bright_cyan(),
+                                f.port.to_string().bright_green()
+                            );
+                            if f.status != "open" {
+                                line.push_str(&format!(" {}", f.status.yellow()));
                             }
+                            if let Some(service) = &f.service {
+                                line.push_str(&format!(" {}", service.bright_magenta()));
+                            }
+                            if let Some(banner) = &f.banner {
+                                line.push_str(&format!(" {}", format!("[{}]", banner).dimmed()));
+                            }
+                            println!("{}", line);
                         }
                     } else {
                         println!("\n{}", "No open ports found 😕".yellow());
@@ -472,6 +496,8 @@ fn main() {
                             proto,
                             latency_ms: f.latency.as_millis(),
                             status: f.status,
+                            service: f.service.clone(),
+                            banner: f.banner.clone(),
                         })
                         .collect();
                     if let Err(e) = emit(&records, format, output_file.as_deref()) {
@@ -617,6 +643,8 @@ fn main() {
                             proto: "tcp",
                             latency_ms: hit.latency.as_millis(),
                             status: "up",
+                            service: None,
+                            banner: None,
                         })
                         .collect();
                     if let Err(e) = emit(&records, format, output_file.as_deref()) {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -59,6 +59,12 @@ pub struct ScanRecord {
     pub latency_ms: u128,
     /// `"open"` for an open port, `"up"` for an available host.
     pub status: &'static str,
+    /// Detected service (from `--sV`), omitted when unknown or not requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<String>,
+    /// Raw service banner (from `--sV`), omitted when none was grabbed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub banner: Option<String>,
 }
 
 /// Render `records` in a machine-readable `format` into a single string.
@@ -156,6 +162,8 @@ mod tests {
                 proto: "tcp",
                 latency_ms: 3,
                 status: "open",
+                service: None,
+                banner: None,
             },
             ScanRecord {
                 ip: "10.0.0.5".to_string(),
@@ -163,6 +171,8 @@ mod tests {
                 proto: "tcp",
                 latency_ms: 12,
                 status: "up",
+                service: None,
+                banner: None,
             },
         ]
     }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -8,9 +8,11 @@
 //! * `well_known` - Frequency-ordered top ports and named port sets
 //! * `exclude` - Address and CDN exclusions for scans
 //! * `nmap` - Handoff of discovered open ports to nmap
+//! * `service` - Banner grabbing and service/version detection
 
 pub mod address;
 pub mod exclude;
 pub mod nmap;
 pub mod port;
+pub mod service;
 pub mod well_known;

--- a/src/scanner/service.rs
+++ b/src/scanner/service.rs
@@ -1,0 +1,211 @@
+//! Lightweight service and version detection (`--sV`).
+//!
+//! Once a TCP port is known to be open, this grabs a small banner from it and
+//! matches that text against a compact set of built-in signatures (SSH, HTTP,
+//! SMTP, FTP, …). It is deliberately not a full nmap-service-probes database —
+//! just enough to answer "what is probably listening here?" without the network
+//! cost or complexity of exhaustive probing.
+//!
+//! Detection has two phases: read whatever the service volunteers on connect
+//! (SSH, SMTP, FTP announce themselves), and if it stays quiet, send a minimal
+//! HTTP request to coax a reply out of web servers.
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::time::Duration;
+
+/// Maximum number of banner bytes read from a service.
+const BANNER_LIMIT: usize = 512;
+
+/// A minimal probe for services that do not speak first; enough to make an HTTP
+/// server reply with its status line and `Server:` header.
+const HTTP_PROBE: &[u8] = b"GET / HTTP/1.0\r\n\r\n";
+
+/// Detect the service on an open TCP `port`, returning `(service, banner)`.
+///
+/// `service` is a short identification derived from the banner (or, failing
+/// that, the well-known port), and `banner` is the sanitized first line the
+/// service sent. Either may be `None` when nothing could be determined.
+pub fn detect(ip: &str, port: u16, timeout: Duration) -> (Option<String>, Option<String>) {
+    let banner = ip
+        .parse::<IpAddr>()
+        .ok()
+        .and_then(|addr| grab_banner(SocketAddr::new(addr, port), timeout));
+
+    let service = banner
+        .as_deref()
+        .and_then(match_service)
+        .map(str::to_string)
+        .or_else(|| service_by_port(port).map(str::to_string));
+
+    (service, banner)
+}
+
+/// Connect and read a banner: take whatever the service offers on connect, and
+/// if it is silent, nudge it with an HTTP request and read again. Returns the
+/// sanitized first line, or `None` if nothing readable came back.
+fn grab_banner(addr: SocketAddr, timeout: Duration) -> Option<String> {
+    let mut stream = TcpStream::connect_timeout(&addr, timeout).ok()?;
+    // Cap the read wait so a chatty-but-slow service cannot stall the scan.
+    let read_timeout = timeout.min(Duration::from_secs(3));
+    stream.set_read_timeout(Some(read_timeout)).ok()?;
+
+    if let Some(banner) = read_banner(&mut stream) {
+        return Some(banner);
+    }
+
+    // Quiet so far: send a tiny HTTP probe and try once more.
+    stream.write_all(HTTP_PROBE).ok()?;
+    read_banner(&mut stream)
+}
+
+/// Read up to [`BANNER_LIMIT`] bytes and sanitize them into a printable first
+/// line. Returns `None` on read error or when nothing (printable) was received.
+fn read_banner(stream: &mut TcpStream) -> Option<String> {
+    let mut buf = [0u8; BANNER_LIMIT];
+    let n = stream.read(&mut buf).ok()?;
+    if n == 0 {
+        return None;
+    }
+    let banner = sanitize(&buf[..n]);
+    if banner.is_empty() {
+        None
+    } else {
+        Some(banner)
+    }
+}
+
+/// Turn raw banner bytes into a single printable line: decode as UTF-8 lossily,
+/// take the first line, keep only printable characters, and trim.
+fn sanitize(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let first_line = text.lines().next().unwrap_or("");
+    first_line
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+/// Match a banner against the built-in signatures, returning a short service
+/// label (often including the product/version the banner revealed).
+pub fn match_service(banner: &str) -> Option<&'static str> {
+    let lower = banner.to_ascii_lowercase();
+
+    // SSH and (E)SMTP/FTP/POP3/IMAP announce themselves on connect.
+    if banner.starts_with("SSH-") {
+        return Some("ssh");
+    }
+    if banner.starts_with("HTTP/") || lower.contains("server:") {
+        return Some("http");
+    }
+    if banner.starts_with("220") && (lower.contains("ftp")) {
+        return Some("ftp");
+    }
+    if banner.starts_with("220") && (lower.contains("smtp") || lower.contains("esmtp")) {
+        return Some("smtp");
+    }
+    if banner.starts_with("+OK") {
+        return Some("pop3");
+    }
+    if banner.starts_with("* OK") {
+        return Some("imap");
+    }
+    if lower.contains("mysql") || lower.contains("mariadb") {
+        return Some("mysql");
+    }
+    if lower.contains("-err") || lower.contains("+pong") || lower.contains("redis") {
+        return Some("redis");
+    }
+    None
+}
+
+/// A best-effort service name for a well-known `port`, used only when no banner
+/// could be matched.
+pub fn service_by_port(port: u16) -> Option<&'static str> {
+    let name = match port {
+        21 => "ftp",
+        22 => "ssh",
+        23 => "telnet",
+        25 | 587 => "smtp",
+        53 => "domain",
+        80 | 8080 | 8000 | 8008 => "http",
+        110 => "pop3",
+        143 => "imap",
+        443 | 8443 => "https",
+        3306 => "mysql",
+        3389 => "rdp",
+        5432 => "postgresql",
+        6379 => "redis",
+        _ => return None,
+    };
+    Some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_ssh_banner() {
+        assert_eq!(match_service("SSH-2.0-OpenSSH_8.9p1 Ubuntu"), Some("ssh"));
+    }
+
+    #[test]
+    fn matches_http_by_status_line_and_server_header() {
+        assert_eq!(match_service("HTTP/1.1 200 OK"), Some("http"));
+        assert_eq!(match_service("Server: nginx/1.25.3"), Some("http"));
+    }
+
+    #[test]
+    fn matches_mail_and_ftp_greetings() {
+        assert_eq!(
+            match_service("220 mail.example.com ESMTP Postfix"),
+            Some("smtp")
+        );
+        assert_eq!(match_service("220 (vsFTPd 3.0.5)"), Some("ftp"));
+        assert_eq!(match_service("+OK POP3 ready"), Some("pop3"));
+    }
+
+    #[test]
+    fn unknown_banner_matches_nothing() {
+        assert_eq!(match_service("random gibberish"), None);
+    }
+
+    #[test]
+    fn falls_back_to_well_known_port_names() {
+        assert_eq!(service_by_port(22), Some("ssh"));
+        assert_eq!(service_by_port(443), Some("https"));
+        assert_eq!(service_by_port(9999), None);
+    }
+
+    #[test]
+    fn sanitize_takes_the_first_printable_line() {
+        assert_eq!(sanitize(b"SSH-2.0-OpenSSH\r\nextra\r\n"), "SSH-2.0-OpenSSH");
+        // Control bytes are stripped; surrounding whitespace trimmed.
+        assert_eq!(sanitize(b"  \x01\x02hello\x03  \n"), "hello");
+        assert_eq!(sanitize(b""), "");
+    }
+
+    #[test]
+    fn detect_reads_a_banner_from_a_local_server() {
+        use std::io::Write;
+        use std::net::TcpListener;
+        use std::thread;
+
+        // A local server that greets like SSH the moment a client connects.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let _ = sock.write_all(b"SSH-2.0-OpenSSH_9.6\r\n");
+            }
+        });
+
+        let (service, banner) = detect("127.0.0.1", port, Duration::from_millis(500));
+        assert_eq!(service.as_deref(), Some("ssh"));
+        assert_eq!(banner.as_deref(), Some("SSH-2.0-OpenSSH_9.6"));
+        let _ = handle.join();
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -412,6 +412,48 @@ fn config_supplies_defaults_that_flags_override() {
 }
 
 #[test]
+fn service_detection_reports_service_and_banner() {
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::thread;
+
+    // A local server that greets like SSH on connect; --sV should identify it
+    // and surface the banner in the JSONL record.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    // The scan makes one probe connection to confirm the port is open, then
+    // --sV makes a second to grab the banner; greet both.
+    let handle = thread::spawn(move || {
+        for _ in 0..2 {
+            match listener.accept() {
+                Ok((mut sock, _)) => {
+                    let _ = sock.write_all(b"SSH-2.0-OpenSSH_9.6\r\n");
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            &port.to_string(),
+            "--sV",
+            "-o",
+            "jsonl",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"service\":\"ssh\""))
+        .stdout(predicate::str::contains("SSH-2.0-OpenSSH_9.6"));
+
+    let _ = handle.join();
+}
+
+#[test]
 fn udp_scan_reports_proto_udp_in_json() {
     // A UDP probe to a closed loopback port typically draws an ICMP
     // port-unreachable (closed → not reported) or stays silent


### PR DESCRIPTION
## What

Closes #12.

An open port reported only its number, not what was listening. Adds `--sV` (alias `--banner`) to grab a banner from each open TCP port and identify the service.

## How

For every open TCP port:

1. **Read what the service volunteers** on connect (SSH/SMTP/FTP announce themselves).
2. If it stays quiet, **send a minimal HTTP request** (`GET / HTTP/1.0`) to coax a reply from web servers.
3. **Match the banner** against a compact set of built-in signatures — SSH, HTTP (status line or `Server:`), SMTP, FTP, POP3/IMAP, MySQL, Redis — falling back to the well-known name for the port when nothing matches.

Deliberately lightweight, not a full nmap-service-probes database; pair it with `--nmap` for exhaustive detection.

## Output

- Text: the service and banner are shown next to the port.
- Machine: `ScanRecord` gains optional `service` and `banner` fields (JSON/JSONL only, omitted when absent — CSV/grep keep their fixed 5-column schema).

## Implementation

- New `src/scanner/service.rs`: `detect`, `grab_banner`, `sanitize`, `match_service`, `service_by_port`.
- `src/output/mod.rs`: `service`/`banner` on `ScanRecord` with `skip_serializing_if`.
- `src/main.rs`: the shared `Finding` carries service/banner; detection runs per open TCP port (skipped for UDP).
- `src/cli/mod.rs`: `--sV` / `--banner` on `ps`.

## Tests

- Unit (offline): signature matching for SSH/HTTP/SMTP/FTP/POP3 and unknowns, well-known port fallback, banner sanitization (first line, control-stripping, empty), and an end-to-end `detect` against a local banner server.
- CLI: `--sV` against a local SSH-like server surfaces `"service":"ssh"` and the banner in JSONL.

## Docs

README (dedicated `--sV` section, examples, flag table) and CLI `--help` updated.