### PR TITLE
Add --resume for long-running port scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -67,6 +67,7 @@ version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "ctrlc",
  "indicatif",
  "ipnetwork",
  "owo-colors",
@@ -99,6 +100,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +136,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -177,7 +199,7 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -206,10 +228,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "either"
@@ -306,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -321,6 +366,18 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -342,6 +399,21 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -670,12 +742,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ipnetwork = "0.20.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+ctrlc = "3.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 
 - **Target sources** — scan a single host, pipe targets in with `--stdin`, or read them from a file with `-i/--target-file`; hosts, IPs, and CIDRs are all accepted, and CIDRs in a file are expanded.
 - **Configuration file** — set defaults (timeout, concurrency, retries, output format) in `~/.asphyxia.toml`; command-line flags override it.
+- **Resumable scans** — checkpoint a long port scan with `--resume <file>` and pick it up where it stopped after a Ctrl-C, crash, or dropped link.
 
 > Note: IPv6 subnet and range scans are capped at 65 536 addresses (e.g. a `/112`), since larger IPv6 spaces are impractical to walk exhaustively.
 
@@ -146,6 +147,7 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
 | `-u, --udp` | Scan UDP ports instead of TCP (results are `open` or `open\|filtered`) |
 | `--sV` (`--banner`) | Grab banners and identify the service on each open TCP port |
+| `--resume <PATH>` | Checkpoint progress to a file and resume from it if it already exists |
 | `--top-ports <N>` | Scan the `N` most common TCP ports (frequency-ordered, up to 1000) |
 | `--ports <NAME>` | Scan a named port set: `web`, `mail`, `db`, `remote`, `windows` |
 | `--exclude-ports <PORTS>` | Remove these comma-separated ports from the scan set |
@@ -186,6 +188,20 @@ asphyxia ps -t example.com -s 22,80,443 --sV
 asphyxia ps -t example.com --top-ports 100 --sV -o jsonl
 # {"ip":"93.184.216.34","port":22,"proto":"tcp","latency_ms":7,"status":"open","service":"ssh","banner":"SSH-2.0-OpenSSH_9.6"}
 ```
+
+#### Resuming a long scan (`--resume`)
+
+A big port scan — many hosts × `--all-ports` — can run for a long time, and losing it to Ctrl-C, a dropped connection, or a crash means starting over. `--resume <file>` checkpoints progress to a state file as the scan runs. Re-run the exact same command with the same file and it picks up where it left off, skipping completed `(host, port)` work and keeping the results already found.
+
+```bash
+# Start a long scan, checkpointing to scan.state
+asphyxia ps -iL targets.txt --all-ports --resume scan.state
+
+# Interrupt it (Ctrl-C) — the state file is flushed on exit — then resume:
+asphyxia ps -iL targets.txt --all-ports --resume scan.state
+```
+
+The state file is written atomically (temp file + rename) so an interrupt mid-write cannot corrupt it, and it is validated on resume: it only continues when the protocol, targets, and ports match the command, so pointing `--resume` at a file from a different scan safely starts fresh instead of producing bogus results.
 
 ### Address scanning (`as`)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,9 @@ Examples:
   # Grab banners and identify services on open ports
   asphyxia ps -t example.com -s 22,80,443 --sV
 
+  # Checkpoint a long scan and resume it after an interruption
+  asphyxia ps -iL targets.txt --all-ports --resume scan.state
+
   # Find open ports fast, then hand them to nmap for a deep dive
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap
   asphyxia ps -t scanme.nmap.org --top-ports 100 --nmap --nmap-args "-A -T4"
@@ -95,6 +98,7 @@ Required arguments:
     --ports <NAME>               Scan a named port set (web, mail, db, remote, windows)
     -u, --udp                    Scan UDP ports instead of TCP (open or open|filtered)
     --sV                         Grab banners and identify the service on each open port
+    --resume <PATH>              Checkpoint progress and resume from PATH if it exists
     --rate <PPS>                 Cap connection attempts per second (0 = no cap)
     -T, --timing <0-5>           Timing profile (paranoid..insane) presetting the tunables
     --timeout <MS>               Connection timeout in milliseconds (default: 2000)
@@ -170,6 +174,10 @@ pub enum Args {
         /// Grab banners and identify the service on each open port (TCP only)
         #[arg(long = "sV", visible_alias = "banner")]
         service_detection: bool,
+
+        /// Checkpoint progress to a file and resume from it if it already exists
+        #[arg(long = "resume", value_name = "PATH")]
+        resume: Option<PathBuf>,
 
         /// After the scan, run nmap on each host's open ports for a deep dive
         #[arg(long = "nmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,14 @@ pub mod cli;
 pub mod config;
 pub mod output;
 pub mod rate;
+pub mod resume;
 pub mod scanner;
 pub mod timing;
 pub mod utils;
 
 pub use config::Config;
 pub use output::{OutputFormat, ScanRecord, emit, render};
+pub use resume::{ScanState, StateFinding};
 pub use scanner::address::{
     HostHit, range_addresses, scan_address, scan_address_with_retries, scan_hosts, scan_ip_range,
     scan_ip_range_with_retries, scan_subnet, scan_subnet_with_retries, subnet_addresses,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use asphyxia::cli::Args;
 use asphyxia::config::Config;
 use asphyxia::output::{OutputFormat, ScanRecord, emit};
 use asphyxia::rate;
+use asphyxia::resume::{ScanState, StateFinding};
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
 use asphyxia::scanner::{address, nmap, port, service};
@@ -127,6 +128,161 @@ fn scan_filtered(
     }
 }
 
+/// Map a persisted status string back to the `&'static str` the report uses.
+fn status_str(status: &str) -> &'static str {
+    if status == "open|filtered" {
+        "open|filtered"
+    } else {
+        "open"
+    }
+}
+
+/// Probe a single `(ip, port)` job, returning a [`Finding`] when the port is
+/// reportable. TCP yields only open ports (optionally with a grabbed banner);
+/// UDP also yields open|filtered.
+#[allow(clippy::too_many_arguments)]
+fn scan_one(
+    udp: bool,
+    ip: String,
+    port: u16,
+    timeout: Option<Duration>,
+    connect_timeout: Duration,
+    retries: u32,
+    detect_service: bool,
+) -> Option<Finding> {
+    if udp {
+        port::scan_udp_port(ip, port, timeout, retries).map(|hit| Finding {
+            port: hit.port,
+            latency: hit.latency,
+            status: if hit.open { "open" } else { "open|filtered" },
+            service: None,
+            banner: None,
+        })
+    } else {
+        port::scan_port_with_retries(ip.clone(), port, timeout, retries).map(|hit| {
+            let (service, banner) = if detect_service {
+                service::detect(&ip, hit.port, connect_timeout)
+            } else {
+                (None, None)
+            };
+            Finding {
+                port: hit.port,
+                latency: hit.latency,
+                status: "open",
+                service,
+                banner,
+            }
+        })
+    }
+}
+
+/// Run a port scan that checkpoints to `state_path` and resumes from it.
+///
+/// A compatible existing state file is loaded and its completed jobs skipped;
+/// otherwise a fresh state is started. Progress is flushed periodically and on
+/// Ctrl-C, and a final flush is written at the end. The returned findings are
+/// the union of prior and freshly-discovered results, sorted by `(host, port)`.
+#[allow(clippy::too_many_arguments)]
+fn run_resumable_port_scan(
+    jobs: &[(usize, u16)],
+    resolved: &[(String, String)],
+    ports: &[u16],
+    proto: &str,
+    udp: bool,
+    timeout: Option<Duration>,
+    connect_timeout: Duration,
+    retries: u32,
+    detect_service: bool,
+    state_path: &Path,
+    pb: &indicatif::ProgressBar,
+) -> Vec<(usize, Finding)> {
+    use std::sync::{Arc, Mutex};
+
+    // Flush the checkpoint to disk at most every this many completed jobs.
+    const FLUSH_EVERY: usize = 128;
+
+    let targets: Vec<String> = resolved.iter().map(|(_, ip)| ip.clone()).collect();
+    let job_count = jobs.len();
+
+    // Resume from a compatible state, else start fresh.
+    let initial = ScanState::load(state_path)
+        .ok()
+        .filter(|s| s.is_compatible(proto, &targets, ports, job_count))
+        .unwrap_or_else(|| ScanState::new(proto, targets.clone(), ports.to_vec(), job_count));
+
+    // Account for already-completed jobs on the progress bar.
+    pb.inc((job_count - initial.remaining()) as u64);
+
+    let state = Arc::new(Mutex::new(initial));
+
+    // On Ctrl-C, flush a valid checkpoint and exit so the scan can be resumed.
+    {
+        let state = Arc::clone(&state);
+        let path = state_path.to_path_buf();
+        let _ = ctrlc::set_handler(move || {
+            if let Ok(s) = state.lock() {
+                let _ = s.save(&path);
+            }
+            eprintln!("\nInterrupted — progress saved to {}", path.display());
+            std::process::exit(130);
+        });
+    }
+
+    jobs.par_iter().enumerate().for_each(|(idx, (i, port))| {
+        if !state.lock().unwrap().is_pending(idx) {
+            return;
+        }
+        let finding = scan_one(
+            udp,
+            resolved[*i].1.clone(),
+            *port,
+            timeout,
+            connect_timeout,
+            retries,
+            detect_service,
+        );
+        let recorded = finding.as_ref().map(|f| StateFinding {
+            host: *i,
+            port: f.port,
+            latency_ms: f.latency.as_millis(),
+            status: f.status.to_string(),
+            service: f.service.clone(),
+            banner: f.banner.clone(),
+        });
+        {
+            let mut s = state.lock().unwrap();
+            s.complete(idx, recorded);
+            if idx % FLUSH_EVERY == 0 {
+                let _ = s.save(state_path);
+            }
+        }
+        pb.inc(1);
+    });
+
+    // Final checkpoint, then rebuild the report from every recorded finding.
+    let state = state.lock().unwrap();
+    let _ = state.save(state_path);
+
+    let mut opened: Vec<(usize, Finding)> = state
+        .findings
+        .iter()
+        .map(|f| {
+            (
+                f.host,
+                Finding {
+                    port: f.port,
+                    latency: Duration::from_millis(f.latency_ms as u64),
+                    status: status_str(&f.status),
+                    service: f.service.clone(),
+                    banner: f.banner.clone(),
+                },
+            )
+        })
+        .collect();
+    opened.sort_by_key(|(i, f)| (*i, f.port));
+    opened
+}
+
 /// Resolve the tunable scan options into `args`, layering three sources under a
 /// strict precedence: an explicit CLI flag beats a `-T` timing profile, which
 /// beats `~/.asphyxia.toml`, which beats the built-in defaults.
@@ -236,6 +392,7 @@ fn main() {
             exclude_cdn,
             udp,
             service_detection,
+            resume,
             nmap,
             nmap_args,
             timeout,
@@ -406,46 +563,44 @@ fn main() {
 
             // Probe every (host, port) pair. TCP yields only open ports; UDP also
             // reports open|filtered (silent) ports, since silence is meaningful.
-            let mut opened: Vec<(usize, Finding)> = jobs
-                .into_par_iter()
-                .filter_map(|(i, port)| {
-                    let ip = resolved[i].1.clone();
-                    let finding = if udp {
-                        port::scan_udp_port(ip, port, timeout, retries).map(|hit| Finding {
-                            port: hit.port,
-                            latency: hit.latency,
-                            status: if hit.open { "open" } else { "open|filtered" },
-                            service: None,
-                            banner: None,
-                        })
-                    } else {
-                        port::scan_port_with_retries(ip.clone(), port, timeout, retries).map(
-                            |hit| {
-                                // For an open TCP port, optionally grab a banner and
-                                // identify the service.
-                                let (service, banner) = if detect_service {
-                                    service::detect(&ip, hit.port, connect_timeout)
-                                } else {
-                                    (None, None)
-                                };
-                                Finding {
-                                    port: hit.port,
-                                    latency: hit.latency,
-                                    status: "open",
-                                    service,
-                                    banner,
-                                }
-                            },
-                        )
-                    };
-                    pb.inc(1);
-                    finding.map(|f| (i, f))
-                })
-                .collect();
+            // With --resume the scan checkpoints to a file and skips work already
+            // recorded there; otherwise it is a plain parallel sweep.
+            let opened: Vec<(usize, Finding)> = if let Some(state_path) = &resume {
+                run_resumable_port_scan(
+                    &jobs,
+                    &resolved,
+                    &ports,
+                    proto,
+                    udp,
+                    timeout,
+                    connect_timeout,
+                    retries,
+                    detect_service,
+                    state_path,
+                    &pb,
+                )
+            } else {
+                let mut opened: Vec<(usize, Finding)> = jobs
+                    .par_iter()
+                    .filter_map(|&(i, port)| {
+                        let finding = scan_one(
+                            udp,
+                            resolved[i].1.clone(),
+                            port,
+                            timeout,
+                            connect_timeout,
+                            retries,
+                            detect_service,
+                        );
+                        pb.inc(1);
+                        finding.map(|f| (i, f))
+                    })
+                    .collect();
+                opened.sort_by_key(|(i, f)| (*i, f.port));
+                opened
+            };
 
             pb.finish_with_message("Scan completed");
-
-            opened.sort_by_key(|(i, f)| (*i, f.port));
 
             match format {
                 OutputFormat::Text => {

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1,0 +1,211 @@
+//! Resumable scan state for long-running port scans.
+//!
+//! A big scan (many hosts × `--all-ports`) can take a long time, and losing it
+//! to a Ctrl-C, a dropped link, or a crash means starting over. With
+//! `--resume <file>` the scan checkpoints its progress to a state file as it
+//! goes; re-running the same command with the same file picks up where it left
+//! off, skipping completed work and keeping the results already found.
+//!
+//! The state is keyed to a deterministic job order — the flattened
+//! `(target, port)` grid — so a boolean per job records what is done and the
+//! same order reproduces on resume. The file is written atomically (temp file
+//! plus rename) so an interrupt mid-write cannot corrupt it.
+
+use std::io;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// One open result recorded in the state file. Mirrors a scan finding plus the
+/// index of the host it belongs to, so the report can be rebuilt on resume.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateFinding {
+    /// Index into [`ScanState::targets`] of the host this result is for.
+    pub host: usize,
+    pub port: u16,
+    pub latency_ms: u128,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub service: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub banner: Option<String>,
+}
+
+/// The persisted state of an in-progress or completed scan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanState {
+    /// Transport of the scan (`"tcp"` or `"udp"`) — a resume must match.
+    pub proto: String,
+    /// Resolved target IPs, in order; the order is part of the job identity.
+    pub targets: Vec<String>,
+    /// Ports scanned, in order.
+    pub ports: Vec<u16>,
+    /// Total number of `(target, port)` jobs; `done` has this length.
+    pub job_count: usize,
+    /// One flag per job in deterministic order: `true` once probed.
+    pub done: Vec<bool>,
+    /// Open results found so far, across every run.
+    pub findings: Vec<StateFinding>,
+}
+
+impl ScanState {
+    /// A fresh state for a scan of `job_count` jobs with nothing done yet.
+    pub fn new(proto: &str, targets: Vec<String>, ports: Vec<u16>, job_count: usize) -> Self {
+        Self {
+            proto: proto.to_string(),
+            targets,
+            ports,
+            job_count,
+            done: vec![false; job_count],
+            findings: Vec::new(),
+        }
+    }
+
+    /// Load a state file, returning an error if it is missing or malformed.
+    pub fn load(path: &Path) -> io::Result<ScanState> {
+        let text = std::fs::read_to_string(path)?;
+        serde_json::from_str(&text).map_err(io::Error::other)
+    }
+
+    /// Write the state to `path` atomically: serialize to a sibling temp file
+    /// and rename it into place, so a crash mid-write leaves the old file intact.
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let json = serde_json::to_string(self).map_err(io::Error::other)?;
+        let tmp = tmp_path(path);
+        std::fs::write(&tmp, json)?;
+        std::fs::rename(&tmp, path)
+    }
+
+    /// Whether a loaded state describes the same scan as the current invocation
+    /// (same protocol, targets, ports, and job count). A mismatch means the
+    /// file belongs to a different scan and must not be resumed.
+    pub fn is_compatible(
+        &self,
+        proto: &str,
+        targets: &[String],
+        ports: &[u16],
+        job_count: usize,
+    ) -> bool {
+        self.proto == proto
+            && self.targets == targets
+            && self.ports == ports
+            && self.job_count == job_count
+            && self.done.len() == job_count
+    }
+
+    /// The number of jobs still to do.
+    pub fn remaining(&self) -> usize {
+        self.done.iter().filter(|d| !**d).count()
+    }
+
+    /// Whether the job at `idx` still needs to be probed.
+    pub fn is_pending(&self, idx: usize) -> bool {
+        !self.done.get(idx).copied().unwrap_or(true)
+    }
+
+    /// Record that job `idx` is done, optionally with an open finding.
+    pub fn complete(&mut self, idx: usize, finding: Option<StateFinding>) {
+        if let Some(slot) = self.done.get_mut(idx) {
+            *slot = true;
+        }
+        if let Some(finding) = finding {
+            self.findings.push(finding);
+        }
+    }
+}
+
+/// The sibling temp path used for atomic writes.
+fn tmp_path(path: &Path) -> std::path::PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ScanState {
+        let mut s = ScanState::new(
+            "tcp",
+            vec!["127.0.0.1".into(), "127.0.0.2".into()],
+            vec![80, 443],
+            4,
+        );
+        s.complete(
+            0,
+            Some(StateFinding {
+                host: 0,
+                port: 80,
+                latency_ms: 5,
+                status: "open".into(),
+                service: Some("http".into()),
+                banner: None,
+            }),
+        );
+        s.complete(1, None);
+        s
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let s = sample();
+        let json = serde_json::to_string(&s).unwrap();
+        let back: ScanState = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn tracks_done_and_remaining() {
+        let s = sample();
+        assert_eq!(s.remaining(), 2);
+        assert!(!s.is_pending(0));
+        assert!(!s.is_pending(1));
+        assert!(s.is_pending(2));
+        assert!(s.is_pending(3));
+    }
+
+    #[test]
+    fn compatibility_requires_matching_shape() {
+        let s = sample();
+        let targets = vec!["127.0.0.1".to_string(), "127.0.0.2".to_string()];
+        assert!(s.is_compatible("tcp", &targets, &[80, 443], 4));
+        // Different protocol, ports, targets, or job count are all incompatible.
+        assert!(!s.is_compatible("udp", &targets, &[80, 443], 4));
+        assert!(!s.is_compatible("tcp", &targets, &[80], 4));
+        assert!(!s.is_compatible("tcp", &["127.0.0.1".to_string()], &[80, 443], 4));
+        assert!(!s.is_compatible("tcp", &targets, &[80, 443], 9));
+    }
+
+    #[test]
+    fn save_then_load_preserves_state() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("asphyxia-state-{}.json", std::process::id()));
+        let s = sample();
+        s.save(&path).expect("save");
+        let back = ScanState::load(&path).expect("load");
+        assert_eq!(s, back);
+        // The temp sibling must not be left behind.
+        assert!(!tmp_path(&path).exists());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn findings_accumulate_across_completes() {
+        let mut s = ScanState::new("tcp", vec!["10.0.0.1".into()], vec![22], 1);
+        assert!(s.findings.is_empty());
+        s.complete(
+            0,
+            Some(StateFinding {
+                host: 0,
+                port: 22,
+                latency_ms: 1,
+                status: "open".into(),
+                service: None,
+                banner: None,
+            }),
+        );
+        assert_eq!(s.findings.len(), 1);
+        assert_eq!(s.remaining(), 0);
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -478,6 +478,65 @@ fn udp_scan_reports_proto_udp_in_json() {
 }
 
 #[test]
+fn resume_writes_a_checkpoint_file() {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-resume-out-{}.json", std::process::id()));
+
+    // A closed-port scan finishes immediately; it must still leave a valid,
+    // fully-completed checkpoint behind.
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1",
+            "--resume",
+            path.to_str().unwrap(),
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let state = std::fs::read_to_string(&path).expect("checkpoint file should exist");
+    assert!(state.contains("\"job_count\":1"));
+    assert!(state.contains("\"done\":[true]"));
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn resume_skips_completed_work_and_reuses_recorded_findings() {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("asphyxia-resume-in-{}.json", std::process::id()));
+
+    // Hand-craft a fully-completed state for `ps -t 127.0.0.1 -s 1` that claims
+    // port 1 is open. Port 1 is actually closed, so seeing it in the output
+    // proves the recorded finding was reused and the job was not re-scanned.
+    let state = r#"{"proto":"tcp","targets":["127.0.0.1"],"ports":[1],"job_count":1,"done":[true],"findings":[{"host":0,"port":1,"latency_ms":7,"status":"open"}]}"#;
+    std::fs::write(&path, state).unwrap();
+
+    asphyxia()
+        .args([
+            "ps",
+            "-t",
+            "127.0.0.1",
+            "-s",
+            "1",
+            "--resume",
+            path.to_str().unwrap(),
+            "-o",
+            "jsonl",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"port\":1"))
+        .stdout(predicate::str::contains("\"status\":\"open\""));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn nmap_args_requires_the_nmap_flag() {
     // --nmap-args without --nmap is a parse error (clap `requires`).
     asphyxia()


### PR DESCRIPTION
## What

Closes #22.

A long port scan (many hosts × `--all-ports`) could not be paused and continued — an interruption meant starting over. Adds `--resume <file>` to checkpoint progress and pick up where it stopped.

## How

- **Checkpointing** — progress is written to a JSON state file keyed to a deterministic flattened `(host, port)` job order: one boolean per job plus the open findings so far. Flushed periodically during the scan and once at the end.
- **Ctrl-C** — a signal handler flushes a valid checkpoint and exits `130`, so the scan can be resumed.
- **Resuming** — re-running the same command loads the state, skips completed jobs, and re-emits the results already found. The file is validated (protocol, targets, ports, job count); an incompatible file safely starts fresh instead of producing bogus output.
- **Crash-safety** — the file is written atomically (temp file + rename), so an interrupt mid-write cannot corrupt it.

Scoped to the `ps` port scan (the `--all-ports`-over-many-hosts case the issue calls out).

## Implementation

- New `src/resume.rs`: `ScanState` / `StateFinding` (serde), with `load`/`save` (atomic), `is_compatible`, `remaining`, `is_pending`, `complete`.
- `src/main.rs`: `scan_one` factors the per-job probe; `run_resumable_port_scan` drives the checkpointed path (shared `Arc<Mutex<ScanState>>`, `ctrlc` handler, periodic flush) and rebuilds the report from all findings. The plain path reuses `scan_one`.
- `src/cli/mod.rs`: `--resume <PATH>` on `ps`.
- New dependency: `ctrlc` (Cargo.lock updated).

## Tests

- Unit: state JSON round-trip, done/remaining tracking, compatibility matching (protocol/ports/targets/job-count mismatches), atomic save→load with no temp file left behind, finding accumulation.
- CLI: a completed scan writes a valid fully-done checkpoint; resuming a hand-crafted completed state re-emits its recorded finding (a port that is actually closed), proving the job was skipped and prior results reused.

## Docs

README (dedicated resume section, flag table, features) and CLI `--help` updated.