### PR TITLE
Add SYN/stealth scan via raw sockets (--syn)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "socket2",
  "toml",
 ]
 
@@ -584,6 +585,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +757,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 ctrlc = "3.4"
+socket2 = { version = "0.5", features = ["all"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Asphyxia is a command-line network scanner that helps you discover open ports on
 - **Target sources** — scan a single host, pipe targets in with `--stdin`, or read them from a file with `-i/--target-file`; hosts, IPs, and CIDRs are all accepted, and CIDRs in a file are expanded.
 - **Configuration file** — set defaults (timeout, concurrency, retries, output format) in `~/.asphyxia.toml`; command-line flags override it.
 - **Resumable scans** — checkpoint a long port scan with `--resume <file>` and pick it up where it stopped after a Ctrl-C, crash, or dropped link.
+- **SYN/stealth scan** — half-open SYN scanning over raw sockets with `--syn` (IPv4, needs privileges), with automatic fallback to the connect scan.
 
 > Note: IPv6 subnet and range scans are capped at 65 536 addresses (e.g. a `/112`), since larger IPv6 spaces are impractical to walk exhaustively.
 
@@ -111,6 +112,9 @@ asphyxia ps -t example.com --top-ports 1000
 # Scan UDP ports instead of TCP (DNS, NTP, SNMP, …)
 asphyxia ps -t example.com -s 53,123,161 --udp
 
+# SYN/stealth scan via raw sockets (needs root/CAP_NET_RAW)
+sudo asphyxia ps -t example.com --top-ports 1000 --syn
+
 # Grab banners and identify services on open ports
 asphyxia ps -t example.com -s 22,80,443 --sV
 
@@ -146,6 +150,7 @@ Exactly one target source is required — `-t/--host`, `--stdin`, or `-i/--targe
 | `-s, --specific <PORTS>` | Scan specific comma-separated ports |
 | `-a, --all-ports` | Scan the entire port range (1-65535) |
 | `-u, --udp` | Scan UDP ports instead of TCP (results are `open` or `open\|filtered`) |
+| `--syn` | SYN/stealth scan via raw sockets (IPv4; needs root/`CAP_NET_RAW`, else falls back to connect) |
 | `--sV` (`--banner`) | Grab banners and identify the service on each open TCP port |
 | `--resume <PATH>` | Checkpoint progress to a file and resume from it if it already exists |
 | `--top-ports <N>` | Scan the `N` most common TCP ports (frequency-ordered, up to 1000) |
@@ -188,6 +193,21 @@ asphyxia ps -t example.com -s 22,80,443 --sV
 asphyxia ps -t example.com --top-ports 100 --sV -o jsonl
 # {"ip":"93.184.216.34","port":22,"proto":"tcp","latency_ms":7,"status":"open","service":"ssh","banner":"SSH-2.0-OpenSSH_9.6"}
 ```
+
+#### SYN / stealth scan (`--syn`)
+
+`--syn` performs a half-open SYN scan over raw sockets: it sends a lone TCP SYN and never completes the handshake — a SYN/ACK means open, a RST means closed, silence means filtered. This is faster and quieter than the default connect scan, at the cost of needing elevated privileges.
+
+```bash
+sudo asphyxia ps -t scanme.nmap.org --top-ports 1000 --syn
+```
+
+Details and limitations:
+
+- **Privileges** — forging raw packets requires root or `CAP_NET_RAW`. Without them, asphyxia prints a notice and automatically falls back to the connect scan, so the command still works unprivileged (just not stealthily).
+- **IPv4 only** — IPv6 targets always use the connect scan.
+- **Correctness fallback** — a port that a SYN probe reports as *filtered* (no reply) is re-checked with a connect probe, so an open port is never missed if a reply is lost. Definitive open/closed SYN results are used directly.
+- `--syn` and `--udp` are mutually exclusive.
 
 #### Resuming a long scan (`--resume`)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,6 +30,9 @@ Examples:
   # Scan UDP ports instead of TCP (open or open|filtered)
   asphyxia ps -t example.com -s 53,123,161 --udp
 
+  # SYN/stealth scan via raw sockets (needs root/CAP_NET_RAW)
+  sudo asphyxia ps -t example.com --top-ports 1000 --syn
+
   # Grab banners and identify services on open ports
   asphyxia ps -t example.com -s 22,80,443 --sV
 
@@ -97,6 +100,7 @@ Required arguments:
     --top-ports <N>              Scan the N most common TCP ports (up to 1000)
     --ports <NAME>               Scan a named port set (web, mail, db, remote, windows)
     -u, --udp                    Scan UDP ports instead of TCP (open or open|filtered)
+    --syn                        SYN/stealth scan via raw sockets (needs root; else connect)
     --sV                         Grab banners and identify the service on each open port
     --resume <PATH>              Checkpoint progress and resume from PATH if it exists
     --rate <PPS>                 Cap connection attempts per second (0 = no cap)
@@ -170,6 +174,10 @@ pub enum Args {
         /// Scan UDP ports instead of TCP (results are open or open|filtered)
         #[arg(short = 'u', long = "udp")]
         udp: bool,
+
+        /// SYN/stealth scan via raw sockets (needs root/CAP_NET_RAW; else falls back to connect)
+        #[arg(long = "syn", conflicts_with = "udp")]
+        syn: bool,
 
         /// Grab banners and identify the service on each open port (TCP only)
         #[arg(long = "sV", visible_alias = "banner")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub use scanner::port::{
     PortHit, UdpHit, is_resolvable, resolve_host, scan_port, scan_port_with_retries, scan_udp_port,
 };
 pub use scanner::service::{detect as detect_service, match_service, service_by_port};
+pub use scanner::syn::{SynOutcome, build_ipv4_syn, classify_flags, parse_ipv4_tcp};
 pub use utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets,
     read_targets_from_file, read_targets_from_stdin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use asphyxia::rate;
 use asphyxia::resume::{ScanState, StateFinding};
 use asphyxia::scanner::exclude::ExcludeSet;
 use asphyxia::scanner::well_known::{named_port_set, top_ports};
-use asphyxia::scanner::{address, nmap, port, service};
+use asphyxia::scanner::{address, nmap, port, service, syn};
 use asphyxia::timing;
 use asphyxia::utils::{
     init_scan_pool, parse_ip, parse_ports, parse_subnet, progress_bar, read_targets_from_file,
@@ -140,6 +140,10 @@ fn status_str(status: &str) -> &'static str {
 /// Probe a single `(ip, port)` job, returning a [`Finding`] when the port is
 /// reportable. TCP yields only open ports (optionally with a grabbed banner);
 /// UDP also yields open|filtered.
+///
+/// With `use_syn`, an IPv4 TCP target is probed with a raw-socket SYN first; a
+/// definitive open/closed result is used directly, while a filtered/unavailable
+/// result falls through to a normal connect probe so nothing open is missed.
 #[allow(clippy::too_many_arguments)]
 fn scan_one(
     udp: bool,
@@ -149,31 +153,55 @@ fn scan_one(
     connect_timeout: Duration,
     retries: u32,
     detect_service: bool,
+    use_syn: bool,
 ) -> Option<Finding> {
     if udp {
-        port::scan_udp_port(ip, port, timeout, retries).map(|hit| Finding {
+        return port::scan_udp_port(ip, port, timeout, retries).map(|hit| Finding {
             port: hit.port,
             latency: hit.latency,
             status: if hit.open { "open" } else { "open|filtered" },
             service: None,
             banner: None,
-        })
-    } else {
-        port::scan_port_with_retries(ip.clone(), port, timeout, retries).map(|hit| {
-            let (service, banner) = if detect_service {
-                service::detect(&ip, hit.port, connect_timeout)
-            } else {
-                (None, None)
-            };
-            Finding {
-                port: hit.port,
-                latency: hit.latency,
-                status: "open",
-                service,
-                banner,
-            }
-        })
+        });
     }
+
+    // SYN pre-check for IPv4: use a definitive answer, else fall through.
+    if use_syn && let Ok(v4) = ip.parse::<std::net::Ipv4Addr>() {
+        match syn::syn_scan_port(v4, port, connect_timeout) {
+            Some(syn::SynOutcome::Open) => {
+                let (service, banner) = if detect_service {
+                    service::detect(&ip, port, connect_timeout)
+                } else {
+                    (None, None)
+                };
+                return Some(Finding {
+                    port,
+                    latency: Duration::ZERO,
+                    status: "open",
+                    service,
+                    banner,
+                });
+            }
+            Some(syn::SynOutcome::Closed) => return None,
+            // Filtered, or raw socket unusable: fall back to a connect probe.
+            Some(syn::SynOutcome::Filtered) | None => {}
+        }
+    }
+
+    port::scan_port_with_retries(ip.clone(), port, timeout, retries).map(|hit| {
+        let (service, banner) = if detect_service {
+            service::detect(&ip, hit.port, connect_timeout)
+        } else {
+            (None, None)
+        };
+        Finding {
+            port: hit.port,
+            latency: hit.latency,
+            status: "open",
+            service,
+            banner,
+        }
+    })
 }
 
 /// Run a port scan that checkpoints to `state_path` and resumes from it.
@@ -193,6 +221,7 @@ fn run_resumable_port_scan(
     connect_timeout: Duration,
     retries: u32,
     detect_service: bool,
+    use_syn: bool,
     state_path: &Path,
     pb: &indicatif::ProgressBar,
 ) -> Vec<(usize, Finding)> {
@@ -240,6 +269,7 @@ fn run_resumable_port_scan(
             connect_timeout,
             retries,
             detect_service,
+            use_syn,
         );
         let recorded = finding.as_ref().map(|f| StateFinding {
             host: *i,
@@ -391,6 +421,7 @@ fn main() {
             exclude_ports,
             exclude_cdn,
             udp,
+            syn,
             service_detection,
             resume,
             nmap,
@@ -403,6 +434,22 @@ fn main() {
             let proto = if udp { "udp" } else { "tcp" };
             // Service detection only makes sense over a TCP stream.
             let detect_service = service_detection && !udp;
+
+            // SYN scanning needs a raw socket (root / CAP_NET_RAW). When asked
+            // for but unavailable, warn once and fall back to the connect scan.
+            let use_syn = if syn && !udp {
+                if syn::raw_socket_available() {
+                    true
+                } else {
+                    eprintln!(
+                        "{}",
+                        "SYN scan needs root/CAP_NET_RAW — falling back to connect scan".yellow()
+                    );
+                    false
+                }
+            } else {
+                false
+            };
 
             let mut ports: Vec<u16> = if all_ports {
                 (1..=u16::MAX).collect()
@@ -576,6 +623,7 @@ fn main() {
                     connect_timeout,
                     retries,
                     detect_service,
+                    use_syn,
                     state_path,
                     &pb,
                 )
@@ -591,6 +639,7 @@ fn main() {
                             connect_timeout,
                             retries,
                             detect_service,
+                            use_syn,
                         );
                         pb.inc(1);
                         finding.map(|f| (i, f))

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -9,10 +9,12 @@
 //! * `exclude` - Address and CDN exclusions for scans
 //! * `nmap` - Handoff of discovered open ports to nmap
 //! * `service` - Banner grabbing and service/version detection
+//! * `syn` - SYN/stealth scan packet assembly and parsing
 
 pub mod address;
 pub mod exclude;
 pub mod nmap;
 pub mod port;
 pub mod service;
+pub mod syn;
 pub mod well_known;

--- a/src/scanner/syn.rs
+++ b/src/scanner/syn.rs
@@ -1,0 +1,366 @@
+//! SYN / stealth scanning (`--syn`, `-sS`).
+//!
+//! A SYN scan sends a lone TCP SYN and never completes the handshake: a SYN/ACK
+//! reply means the port is open (we answer with a RST instead of an ACK), a RST
+//! means closed, and silence means filtered. It is faster and quieter than a
+//! full connect scan, but forging raw TCP/IP packets needs elevated privileges
+//! (root / `CAP_NET_RAW`).
+//!
+//! This module is split so the risky, privilege-bound network I/O is separate
+//! from the pure, exhaustively-tested packet machinery:
+//!
+//! * [`build_ipv4_syn`] / [`build_tcp_syn`] assemble the bytes on the wire,
+//! * [`parse_ipv4_tcp`] and [`classify_flags`] interpret a reply,
+//! * [`raw_socket_available`] reports whether a raw socket can be opened, so the
+//!   caller can fall back to a connect scan with a clear message when it cannot.
+//!
+//! IPv4 only: IPv6 SYN scanning is not implemented and callers fall back.
+
+use std::mem::MaybeUninit;
+use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+use std::time::{Duration, Instant};
+
+/// TCP control-flag bits.
+pub const TCP_FIN: u8 = 0x01;
+pub const TCP_SYN: u8 = 0x02;
+pub const TCP_RST: u8 = 0x04;
+pub const TCP_ACK: u8 = 0x10;
+
+/// Length of a TCP header with no options.
+const TCP_HEADER_LEN: usize = 20;
+/// Length of an IPv4 header with no options.
+const IPV4_HEADER_LEN: usize = 20;
+/// IANA protocol number for TCP.
+const IPPROTO_TCP: u8 = 6;
+
+/// How a SYN probe's reply is interpreted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SynOutcome {
+    /// SYN/ACK — the port is open.
+    Open,
+    /// RST — the port is closed.
+    Closed,
+    /// Anything else (or no reply) — filtered/indeterminate.
+    Filtered,
+}
+
+/// Classify a TCP reply from its flag byte: RST is closed, SYN+ACK is open,
+/// everything else is filtered.
+pub fn classify_flags(flags: u8) -> SynOutcome {
+    if flags & TCP_RST != 0 {
+        SynOutcome::Closed
+    } else if flags & TCP_SYN != 0 && flags & TCP_ACK != 0 {
+        SynOutcome::Open
+    } else {
+        SynOutcome::Filtered
+    }
+}
+
+/// One's-complement 16-bit checksum over `data` (RFC 1071), used for both the
+/// IPv4 header and the TCP segment (the latter over a pseudo-header).
+fn checksum(data: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let mut chunks = data.chunks_exact(2);
+    for pair in &mut chunks {
+        sum += u32::from(u16::from_be_bytes([pair[0], pair[1]]));
+    }
+    if let [last] = chunks.remainder() {
+        sum += u32::from(u16::from_be_bytes([*last, 0]));
+    }
+    while sum >> 16 != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+/// Build a bare TCP SYN segment (20 bytes, no options) with its checksum filled
+/// in over the IPv4 pseudo-header.
+pub fn build_tcp_syn(
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    seq: u32,
+) -> Vec<u8> {
+    let mut seg = vec![0u8; TCP_HEADER_LEN];
+    seg[0..2].copy_from_slice(&src_port.to_be_bytes());
+    seg[2..4].copy_from_slice(&dst_port.to_be_bytes());
+    seg[4..8].copy_from_slice(&seq.to_be_bytes());
+    // ack number stays 0 (bytes 8..12).
+    seg[12] = 0x50; // data offset = 5 (20 bytes) in the high nibble.
+    seg[13] = TCP_SYN;
+    seg[14..16].copy_from_slice(&1024u16.to_be_bytes()); // window
+    // checksum (16..18) left zero for the computation.
+    // urgent pointer (18..20) stays 0.
+
+    // Pseudo-header: src, dst, zero, proto, tcp length.
+    let mut pseudo = Vec::with_capacity(12 + TCP_HEADER_LEN);
+    pseudo.extend_from_slice(&src.octets());
+    pseudo.extend_from_slice(&dst.octets());
+    pseudo.push(0);
+    pseudo.push(IPPROTO_TCP);
+    pseudo.extend_from_slice(&(TCP_HEADER_LEN as u16).to_be_bytes());
+    pseudo.extend_from_slice(&seg);
+
+    let sum = checksum(&pseudo);
+    seg[16..18].copy_from_slice(&sum.to_be_bytes());
+    seg
+}
+
+/// Build a complete IPv4 packet carrying a TCP SYN, including a valid IPv4
+/// header checksum.
+pub fn build_ipv4_syn(
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    seq: u32,
+) -> Vec<u8> {
+    let tcp = build_tcp_syn(src, dst, src_port, dst_port, seq);
+    let total_len = (IPV4_HEADER_LEN + tcp.len()) as u16;
+
+    let mut ip = vec![0u8; IPV4_HEADER_LEN];
+    ip[0] = 0x45; // version 4, IHL 5 (20 bytes)
+    // DSCP/ECN (1) stays 0.
+    ip[2..4].copy_from_slice(&total_len.to_be_bytes());
+    // identification (4..6) stays 0.
+    ip[6..8].copy_from_slice(&0x4000u16.to_be_bytes()); // don't fragment
+    ip[8] = 64; // TTL
+    ip[9] = IPPROTO_TCP;
+    // header checksum (10..12) left zero for the computation.
+    ip[12..16].copy_from_slice(&src.octets());
+    ip[16..20].copy_from_slice(&dst.octets());
+
+    let sum = checksum(&ip);
+    ip[10..12].copy_from_slice(&sum.to_be_bytes());
+
+    ip.extend_from_slice(&tcp);
+    ip
+}
+
+/// Parse an IPv4 packet that carries TCP, returning `(src_port, dst_port,
+/// flags)`. Returns `None` if the buffer is too short, not IPv4, or not TCP.
+pub fn parse_ipv4_tcp(packet: &[u8]) -> Option<(u16, u16, u8)> {
+    if packet.len() < IPV4_HEADER_LEN {
+        return None;
+    }
+    // Version must be 4.
+    if packet[0] >> 4 != 4 {
+        return None;
+    }
+    let ihl = (packet[0] & 0x0f) as usize * 4;
+    if ihl < IPV4_HEADER_LEN || packet.len() < ihl {
+        return None;
+    }
+    if packet[9] != IPPROTO_TCP {
+        return None;
+    }
+    let tcp = &packet[ihl..];
+    if tcp.len() < TCP_HEADER_LEN {
+        return None;
+    }
+    let src_port = u16::from_be_bytes([tcp[0], tcp[1]]);
+    let dst_port = u16::from_be_bytes([tcp[2], tcp[3]]);
+    let flags = tcp[13];
+    Some((src_port, dst_port, flags))
+}
+
+/// Whether a raw TCP socket can be opened — i.e. whether the process has the
+/// privileges needed for a SYN scan. When this is `false`, callers should fall
+/// back to a connect scan.
+pub fn raw_socket_available() -> bool {
+    use socket2::{Domain, Protocol, Socket, Type};
+    Socket::new(
+        Domain::IPV4,
+        Type::RAW,
+        Some(Protocol::from(i32::from(IPPROTO_TCP))),
+    )
+    .is_ok()
+}
+
+/// Discover the local IPv4 address the kernel would use to reach `dst`, without
+/// sending anything: connecting a UDP socket only sets its route.
+fn local_ipv4_for(dst: Ipv4Addr) -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect(SocketAddr::new(dst.into(), 80)).ok()?;
+    match socket.local_addr().ok()?.ip() {
+        std::net::IpAddr::V4(v4) => Some(v4),
+        std::net::IpAddr::V6(_) => None,
+    }
+}
+
+/// Perform a single SYN probe against `dst:dst_port` over a raw socket and
+/// classify the reply. Returns `None` if a raw socket cannot be used (no
+/// privileges, platform limitation, or send error), signalling the caller to
+/// fall back to a connect probe.
+///
+/// This is the privilege-bound path: it forges a SYN, sends it, and reads
+/// replies until it sees the matching SYN/ACK or RST, or the timeout elapses
+/// (reported as [`SynOutcome::Filtered`]).
+pub fn syn_scan_port(dst: Ipv4Addr, dst_port: u16, timeout: Duration) -> Option<SynOutcome> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    // Respect the global rate limit (no-op when none is installed).
+    crate::rate::gate();
+
+    let src = local_ipv4_for(dst)?;
+    // A source port derived from the destination keeps concurrent probes from
+    // colliding, since each job has a distinct destination port.
+    let src_port = 40000u16.wrapping_add(dst_port);
+    let segment = build_tcp_syn(src, dst, src_port, dst_port, 0x1234_5678);
+
+    let socket = Socket::new(
+        Domain::IPV4,
+        Type::RAW,
+        Some(Protocol::from(i32::from(IPPROTO_TCP))),
+    )
+    .ok()?;
+    socket.set_read_timeout(Some(timeout)).ok()?;
+
+    let destination: socket2::SockAddr = SocketAddr::new(dst.into(), dst_port).into();
+    socket.send_to(&segment, &destination).ok()?;
+
+    // Read replies until the one addressed to our probe arrives or time runs out.
+    let deadline = Instant::now() + timeout;
+    let mut buf = [MaybeUninit::<u8>::uninit(); 1500];
+    while Instant::now() < deadline {
+        let Ok(n) = socket.recv(&mut buf) else {
+            break;
+        };
+        // Safety: `recv` reports `n` initialised bytes at the front of `buf`.
+        let packet = unsafe { &*(&buf[..n] as *const [MaybeUninit<u8>] as *const [u8]) };
+        if let Some((reply_src, reply_dst, flags)) = parse_ipv4_tcp(packet)
+            && reply_src == dst_port
+            && reply_dst == src_port
+        {
+            return Some(classify_flags(flags));
+        }
+    }
+    // No matching reply within the window: treat as filtered.
+    Some(SynOutcome::Filtered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_covers_open_closed_filtered() {
+        assert_eq!(classify_flags(TCP_SYN | TCP_ACK), SynOutcome::Open);
+        assert_eq!(classify_flags(TCP_RST | TCP_ACK), SynOutcome::Closed);
+        assert_eq!(classify_flags(TCP_RST), SynOutcome::Closed);
+        assert_eq!(classify_flags(TCP_ACK), SynOutcome::Filtered);
+        assert_eq!(classify_flags(0), SynOutcome::Filtered);
+    }
+
+    #[test]
+    fn checksum_of_a_valid_block_verifies_to_zero() {
+        // Summing a block that already contains its own checksum yields 0.
+        let ip = build_ipv4_syn(
+            "10.0.0.1".parse().unwrap(),
+            "10.0.0.2".parse().unwrap(),
+            40000,
+            80,
+            0x11223344,
+        );
+        // IPv4 header (first 20 bytes) checksums to zero when the stored sum is
+        // included.
+        assert_eq!(checksum(&ip[..IPV4_HEADER_LEN]), 0);
+    }
+
+    #[test]
+    fn tcp_syn_has_expected_shape_and_valid_checksum() {
+        let src: Ipv4Addr = "192.168.1.10".parse().unwrap();
+        let dst: Ipv4Addr = "192.168.1.20".parse().unwrap();
+        let seg = build_tcp_syn(src, dst, 50000, 443, 0xdeadbeef);
+        assert_eq!(seg.len(), TCP_HEADER_LEN);
+        assert_eq!(u16::from_be_bytes([seg[0], seg[1]]), 50000);
+        assert_eq!(u16::from_be_bytes([seg[2], seg[3]]), 443);
+        assert_eq!(seg[12] >> 4, 5, "data offset should be 5 words");
+        assert_eq!(seg[13], TCP_SYN, "only the SYN flag should be set");
+
+        // Re-checksumming the pseudo-header + segment must verify to zero.
+        let mut pseudo = Vec::new();
+        pseudo.extend_from_slice(&src.octets());
+        pseudo.extend_from_slice(&dst.octets());
+        pseudo.push(0);
+        pseudo.push(IPPROTO_TCP);
+        pseudo.extend_from_slice(&(TCP_HEADER_LEN as u16).to_be_bytes());
+        pseudo.extend_from_slice(&seg);
+        assert_eq!(checksum(&pseudo), 0);
+    }
+
+    #[test]
+    fn ipv4_syn_total_length_and_protocol_are_correct() {
+        let ip = build_ipv4_syn(
+            "1.2.3.4".parse().unwrap(),
+            "5.6.7.8".parse().unwrap(),
+            33333,
+            22,
+            1,
+        );
+        assert_eq!(ip.len(), IPV4_HEADER_LEN + TCP_HEADER_LEN);
+        assert_eq!(ip[0] >> 4, 4, "version 4");
+        assert_eq!(
+            u16::from_be_bytes([ip[2], ip[3]]) as usize,
+            IPV4_HEADER_LEN + TCP_HEADER_LEN
+        );
+        assert_eq!(ip[9], IPPROTO_TCP);
+    }
+
+    #[test]
+    fn build_then_parse_round_trips_ports_and_flags() {
+        let ip = build_ipv4_syn(
+            "10.1.1.1".parse().unwrap(),
+            "10.1.1.2".parse().unwrap(),
+            44444,
+            8080,
+            42,
+        );
+        let (src_port, dst_port, flags) = parse_ipv4_tcp(&ip).expect("should parse");
+        assert_eq!(src_port, 44444);
+        assert_eq!(dst_port, 8080);
+        assert_eq!(flags, TCP_SYN);
+    }
+
+    #[test]
+    fn parse_rejects_non_ipv4_and_non_tcp() {
+        assert!(parse_ipv4_tcp(&[]).is_none());
+        // Version 6 nibble.
+        assert!(parse_ipv4_tcp(&[0x60; 40]).is_none());
+        // IPv4 but protocol 17 (UDP), not TCP.
+        let mut pkt = build_ipv4_syn(
+            "1.1.1.1".parse().unwrap(),
+            "2.2.2.2".parse().unwrap(),
+            1,
+            2,
+            3,
+        );
+        pkt[9] = 17;
+        assert!(parse_ipv4_tcp(&pkt).is_none());
+    }
+
+    #[test]
+    fn parse_handles_ip_options() {
+        // An IHL of 6 (24-byte header) shifts where the TCP segment begins.
+        let mut pkt = build_ipv4_syn(
+            "9.9.9.9".parse().unwrap(),
+            "8.8.8.8".parse().unwrap(),
+            12345,
+            53,
+            7,
+        );
+        // Splice 4 bytes of IP options in and bump IHL + total length.
+        let tcp = pkt.split_off(IPV4_HEADER_LEN);
+        pkt.extend_from_slice(&[0u8; 4]); // dummy options
+        pkt.extend_from_slice(&tcp);
+        pkt[0] = 0x46; // IHL = 6
+        let new_len = pkt.len() as u16;
+        pkt[2..4].copy_from_slice(&new_len.to_be_bytes());
+
+        let (src_port, dst_port, flags) = parse_ipv4_tcp(&pkt).expect("should parse with options");
+        assert_eq!(src_port, 12345);
+        assert_eq!(dst_port, 53);
+        assert_eq!(flags, TCP_SYN);
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -454,6 +454,28 @@ fn service_detection_reports_service_and_banner() {
 }
 
 #[test]
+fn syn_conflicts_with_udp() {
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "--syn", "--udp"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn syn_scan_runs_or_falls_back_cleanly() {
+    // Port 1 on loopback is closed. Whether the process can open a raw socket
+    // (SYN → RST → closed) or not (falls back to connect → refused → closed),
+    // the reported result is the same empty JSON array. This exercises the
+    // capability check and fallback without needing privileges in CI.
+    asphyxia()
+        .args(["ps", "-t", "127.0.0.1", "-s", "1", "--syn", "-o", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("[]\n"));
+}
+
+#[test]
 fn udp_scan_reports_proto_udp_in_json() {
     // A UDP probe to a closed loopback port typically draws an ICMP
     // port-unreachable (closed → not reported) or stays silent


### PR DESCRIPTION
## What

Closes #21. The largest, separate-track item.

The default connect scan completes a full TCP handshake on every port — reliable, but slower and noisier than a half-open SYN scan. Adds `--syn` (IPv4) for a SYN/stealth scan: send a lone SYN, never finish the handshake, and read the reply (SYN/ACK → open, RST → closed, silence → filtered).

## Design

The module is split so the risky, privilege-bound network I/O is separate from the pure, exhaustively-tested packet machinery:

- **Packet engine (tested offline)** — `build_ipv4_syn` / `build_tcp_syn` assemble the IPv4 + TCP SYN bytes with correct IPv4-header and TCP (pseudo-header) checksums; `parse_ipv4_tcp` and `classify_flags` interpret replies. All verified without a network.
- **Capability + fallback** — `raw_socket_available` reports whether a raw socket can be opened. `--syn` without root/`CAP_NET_RAW` prints a clear notice and **automatically falls back to the connect scan**, so the command still works unprivileged.
- **Privileged path** — `syn_scan_port` forges the SYN, sends it on a raw socket, and reads replies until the matching SYN/ACK or RST arrives (or a timeout → filtered).
- **Correctness fallback** — a *filtered* SYN result (no reply) is re-checked with a connect probe, so a lost reply never hides an open port; definitive open/closed SYN results are used directly.

Limitations (documented): IPv4 only (IPv6 uses connect); `--syn` conflicts with `--udp`.

## Implementation

- New `src/scanner/syn.rs`: checksum, `build_tcp_syn`, `build_ipv4_syn`, `parse_ipv4_tcp`, `classify_flags`, `raw_socket_available`, `syn_scan_port`.
- `src/main.rs`: `scan_one` gains a `use_syn` path (SYN pre-check with connect fallback); `main` performs the capability check once and warns before falling back.
- `src/cli/mod.rs`: `--syn` (conflicts with `--udp`).
- New dependency: `socket2` (feature `all`, for raw sockets); Cargo.lock updated.

## Tests

- Unit (offline): flag classification (open/closed/filtered), IPv4-header and TCP checksums verify to zero, SYN segment shape (ports, data offset, flags), IPv4 total length/protocol, build→parse round-trip of ports/flags, and parse rejects non-IPv4/non-TCP and handles IP options.
- CLI: `--syn` conflicts with `--udp`; a `--syn` scan of a closed loopback port succeeds and yields `[]` whether it runs SYN (root) or falls back (unprivileged) — exercising the capability check and fallback without needing privileges in CI.

## Docs

README (dedicated SYN section with the privilege/IPv4/fallback caveats, examples, flag table, features) and CLI `--help` updated.