### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "asphyxia"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asphyxia"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = [
     "Mikhail Savin <jtprogru@gmail.com>"


### PR DESCRIPTION
Release 0.7.0.

This release adds twelve features on top of 0.6.0, all backwards-compatible (new flags and optional output fields only):

- `--top-ports` / `--ports` named sets (#11)
- CSV & greppable output + `--output-file` (#18)
- `--retries` for lossy networks (#16)
- Multi-port host discovery + `--Pn` (#19)
- Exclusions: `--exclude` / `--exclude-file` / `--exclude-ports` / `--exclude-cdn` (#17)
- Nmap handoff `--nmap` (#13)
- Target file `-iL` + `~/.asphyxia.toml` config (#20)
- Rate limiting `--rate` + timing profiles `-T0..5` (#15)
- UDP scanning `--udp` (#14)
- Service/version detection `--sV` (#12)
- Resumable scans `--resume` (#22)
- SYN/stealth scan `--syn` (#21)

Version bumped in `Cargo.toml` and `Cargo.lock`. Tag `0.7.0` will be pushed after merge to trigger the release build.