### PR TITLE
test: isolate CLI tests from a real ~/.asphyxia.toml

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,7 +8,13 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 fn asphyxia() -> Command {
-    Command::cargo_bin("asphyxia").expect("binary `asphyxia` should be built")
+    let mut cmd = Command::cargo_bin("asphyxia").expect("binary `asphyxia` should be built");
+    // Isolate every run from a real `~/.asphyxia.toml` on the developer's
+    // machine by pointing the config loader at a path that does not exist, so
+    // tests always start from the built-in defaults. Tests that exercise config
+    // behaviour set their own `ASPHYXIA_CONFIG`, which overrides this.
+    cmd.env("ASPHYXIA_CONFIG", "/nonexistent/asphyxia-test-config.toml");
+    cmd
 }
 
 #[test]


### PR DESCRIPTION
## Проблема

Сквозные CLI-тесты (`tests/cli.rs`) запускают собранный бинарник, а он читает `\$HOME/.asphyxia.toml`. На машине разработчика с реальным конфигом тесты «дефолтного вывода» падали:

- `text_output_remains_the_default`
- `nmap_flag_with_no_open_ports_does_not_invoke_nmap`

Конфиг (`output = "jsonl"`) молча переопределял формат вывода, поэтому текстовый баннер (`Game Over` / `No open ports found`) не печатался, и `stdout` оказывался пустым. На CI без такого файла тесты проходили — то есть зелёный CI маскировал хрупкость тестов.

## Решение

Общий тест-хелпер `asphyxia()` теперь по умолчанию выставляет `ASPHYXIA_CONFIG` на несуществующий путь, чтобы каждый запуск стартовал с встроенных дефолтов независимо от реального конфига на машине.

Тесты, которые целенаправленно проверяют поведение конфига (`config_supplies_defaults_that_flags_override`), задают свой `ASPHYXIA_CONFIG` — их `.env()` переопределяет дефолт хелпера, поэтому они продолжают работать.

## Проверка

`make test` — все тесты проходят (87 + 52 + 16, 0 упавших).